### PR TITLE
Setting modified on and modified by on FakeUpdate now, too

### DIFF
--- a/FakeXrmEasy.Tests/FakeContextTests/FakeContextTests.cs
+++ b/FakeXrmEasy.Tests/FakeContextTests/FakeContextTests.cs
@@ -7,6 +7,7 @@ using FakeXrmEasy;
 using System.Collections.Generic;
 using Microsoft.Xrm.Sdk;
 using System.Linq;
+using System.Threading;
 using FakeXrmEasy.Tests.PluginsForTesting;
 
 namespace FakeXrmEasy.Tests
@@ -142,6 +143,24 @@ namespace FakeXrmEasy.Tests
 
         }
 
-        
+        [Fact]
+        public void When_updating_an_entity_Modified_On_Should_Also_Be_Updated()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetFakedOrganizationService();
+
+            var e = new Entity("account") { Id = Guid.NewGuid() };
+            context.Initialize(new List<Entity>() { e });
+
+            var oldModifiedOn = (DateTime)e["modifiedon"];
+
+            Thread.Sleep(1000);
+
+            service.Update(e);
+            var newModifiedOn = (DateTime)e["modifiedon"];
+
+            Assert.NotEqual(oldModifiedOn, newModifiedOn);
+        }
+
     }
 }

--- a/FakeXrmEasy/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy/XrmFakedContext.Crud.cs
@@ -129,11 +129,14 @@ namespace FakeXrmEasy
                     {
                         //Add as many attributes to the entity as the ones received (this will keep existing ones)
                         var cachedEntity = context.Data[e.LogicalName][e.Id];
-                        foreach (var sAttributeName in e.Attributes.Keys)
+                        foreach (var sAttributeName in e.Attributes.Keys.ToList())
                         {
                             cachedEntity[sAttributeName] = e[sAttributeName];
                         }
-                        
+
+                        // Update ModifiedOn
+                        cachedEntity["modifiedon"] = DateTime.UtcNow;
+                        cachedEntity["modifiedby"] = context.CallerId;
                     }
                     else
                     {


### PR DESCRIPTION
Hey Jordi,

I found that the update function is not updating the modifiedOn and modifiedBy properties of an entity.
So I added updating those to the FakeUpdate function.

Please note, that already in the previous commit there were tests failing:
FakeXrmEasy.Tests.FakeContextTests.LinqTests.EqualityWithDifferentDataTypesTests.When_executing_a_linq_query_with_equals_between_2_activityparties_result_is_returned
=> Assert.True() Failure

PS: Do you think you could publish an updated version in Nuget? I don't want to use local builds for all projects.

Kind Regards,
DigitalFlow