### PR TITLE
Added possibility for mocking various request types

### DIFF
--- a/FakeXrmEasy.Tests/FakeContextTests/FakeContextMockTests.cs
+++ b/FakeXrmEasy.Tests/FakeContextTests/FakeContextMockTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.FakeContextTests
+{
+    public class FakeContextMockTests
+    {
+        [Fact]
+        public void Should_Execute_Mock_For_OrganizationRequests()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetFakedOrganizationService();
+
+            var e = new Entity("Contact") { Id = Guid.NewGuid() };
+            context.Initialize(new[] { e });
+            context.AddExecutionMock<RetrieveEntityRequest>(RetrieveEntityMock);
+
+            var inputs = new ParameterCollection
+            {
+                {"Target", e }
+            };
+
+            context.ExecutePluginWith<CustomMockPlugin>(inputs, new ParameterCollection(), new EntityImageCollection(), new EntityImageCollection());
+
+            Assert.Equal("Successful", (string)e["response"]);
+            Assert.DoesNotThrow(() => context.RemoveExecutionMock<RetrieveEntityRequest>());
+        }
+
+        public OrganizationResponse RetrieveEntityMock(OrganizationRequest req)
+        {
+            return new RetrieveEntityResponse {ResponseName = "Successful"};
+        }
+    }
+}

--- a/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
+++ b/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="CodeActivitiesForTesting\AddActivityWithConstant.cs" />
     <Compile Include="CodeActivitiesForTesting\AddActivity.cs" />
     <Compile Include="CodeActivitiesForTesting\CreateTaskActivity.cs" />
+    <Compile Include="FakeContextTests\FakeContextMockTests.cs" />
     <Compile Include="FakeContextTests\FakeContextTestCodeActivities.cs" />
     <Compile Include="FakeContextTests\FakeContextTestCreateQuery.cs" />
     <Compile Include="FakeContextTests\FakeContextTestDelete.cs" />
@@ -98,6 +99,7 @@
     <Compile Include="GeneratedCode.cs" />
     <Compile Include="PluginsForTesting\AccountNumberPlugin.cs" />
     <Compile Include="PluginsForTesting\ConfigurationPlugin.cs" />
+    <Compile Include="PluginsForTesting\CustomMockPlugin.cs" />
     <Compile Include="PluginsForTesting\FollowupPlugin.cs" />
     <Compile Include="PluginsForTesting\RetrieveServicesPlugin.cs" />
     <Compile Include="PluginsForTesting\TestContextPlugin.cs" />

--- a/FakeXrmEasy.Tests/PluginsForTesting/CustomMockPlugin.cs
+++ b/FakeXrmEasy.Tests/PluginsForTesting/CustomMockPlugin.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+
+namespace FakeXrmEasy.Tests
+{
+    public class CustomMockPlugin : IPlugin
+    {
+        public void Execute(IServiceProvider serviceProvider)
+        {
+            var tracing = (ITracingService) serviceProvider.GetService(typeof (ITracingService));
+            var context = (IPluginExecutionContext) serviceProvider.GetService(typeof (IPluginExecutionContext));
+            var factory = (IOrganizationServiceFactory) serviceProvider.GetService(typeof (IOrganizationServiceFactory));
+            var service = factory.CreateOrganizationService(context.UserId);
+
+            var request = new RetrieveEntityRequest
+            {
+                LogicalName = "Contact",
+                EntityFilters = EntityFilters.All,
+                RetrieveAsIfPublished = false
+            };
+
+            var response = (RetrieveEntityResponse)service.Execute(request);
+
+            var target = ((Entity) context.InputParameters["Target"]);
+            target["response"] = response.ResponseName;
+        }
+    }
+}

--- a/FakeXrmEasy/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy/XrmFakedContext.Plugins.cs
@@ -47,6 +47,8 @@ namespace FakeXrmEasy
             A.CallTo(() => context.MessageName).ReturnsLazily(() => ctx.MessageName);
             A.CallTo(() => context.InitiatingUserId).ReturnsLazily(() => ctx.InitiatingUserId == Guid.Empty ? newUserId : ctx.InitiatingUserId);
             A.CallTo(() => context.UserId).ReturnsLazily(() => ctx.UserId == Guid.Empty ? newUserId : ctx.UserId);
+            A.CallTo(() => context.ParentContext).ReturnsLazily(() => ctx.ParentContext);
+            A.CallTo(() => context.Stage).ReturnsLazily(() => ctx.Stage);
 
             //Create message will pass an Entity as the target but this is not always true
             //For instance, a Delete request will receive an EntityReference


### PR DESCRIPTION
Hey @jordimontana82,

I recently had the need to test plugins with some very special requests, that were not implemented in FakeXRMEasy.
Therefore I wanted to add means for easily passing in mocks for those requests.
With the additions in this pull request you can add delegates to a dictionary of the XrmFakedContext, which will be executed if the request, that they are defined for, is sent to the context.

Kind Regards