### PR TITLE
Fixed mixup of intersect entity schema name and logical name

### DIFF
--- a/FakeXrmEasy.Tests/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
+++ b/FakeXrmEasy.Tests/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
@@ -34,7 +34,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
 
             fakedContext.Initialize(new Entity[] { testUser, testRole });
 
-            fakedContext.AddRelationship("systemuserroles", new XrmFakedRelationship
+            fakedContext.AddRelationship("systemuserroles_association", new XrmFakedRelationship
             {
                 IntersectEntity = "systemuserroles",
                 Entity1LogicalName = SystemUser.EntityLogicalName,
@@ -50,7 +50,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
                 {
                     new EntityReference(Role.EntityLogicalName, testRole.Id),
                 },
-                Relationship = new Relationship("systemuserroles")
+                Relationship = new Relationship("systemuserroles_association")
             };
 
             fakedService.Execute(request);
@@ -119,7 +119,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
 
             fakedContext.Initialize(new Entity[] { testUser, testRole, testUser2, testRole2 });
 
-            fakedContext.AddRelationship("systemuserroles", new XrmFakedRelationship
+            fakedContext.AddRelationship("systemuserroles_association", new XrmFakedRelationship
             {
                 IntersectEntity = "systemuserroles",
                 Entity1LogicalName = SystemUser.EntityLogicalName,
@@ -135,7 +135,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
                 {
                     new EntityReference(Role.EntityLogicalName, testRole.Id),
                 },
-                Relationship = new Relationship("systemuserroles")
+                Relationship = new Relationship("systemuserroles_association")
             };
 
             fakedService.Execute(request);
@@ -147,7 +147,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
                 {
                     new EntityReference(Role.EntityLogicalName, testRole2.Id),
                 },
-                Relationship = new Relationship("systemuserroles")
+                Relationship = new Relationship("systemuserroles_association")
             };
 
             fakedService.Execute(request2);
@@ -204,7 +204,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
 
             fakedContext.Initialize(new Entity[] { testUser, testRole });
 
-            fakedContext.AddRelationship("systemuserroles", new XrmFakedRelationship
+            fakedContext.AddRelationship("systemuserroles_association", new XrmFakedRelationship
             {
                 IntersectEntity = "systemuserroles",
                 Entity1LogicalName = SystemUser.EntityLogicalName,
@@ -220,7 +220,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
                 {
                     new EntityReference(Role.EntityLogicalName, testRole.Id),
                 },
-                Relationship = new Relationship("systemuserroles")
+                Relationship = new Relationship("systemuserroles_association")
             };
 
             fakedService.Execute(request);
@@ -232,7 +232,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
                 {
                     new EntityReference(Role.EntityLogicalName, testRole.Id),
                 },
-                Relationship = new Relationship("systemuserroles")
+                Relationship = new Relationship("systemuserroles_association")
             };
 
             fakedService.Execute(disassociate);

--- a/FakeXrmEasy/FakeMessageExecutors/AssociateRequestExecutor.cs
+++ b/FakeXrmEasy/FakeMessageExecutors/AssociateRequestExecutor.cs
@@ -38,7 +38,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             foreach (var relatedEntity in associateRequest.RelatedEntities)
             {
-                var association = new Entity(relationShipName)
+                var association = new Entity(relationShip.IntersectEntity)
                 {
                     Attributes = new AttributeCollection
                         {

--- a/FakeXrmEasy/FakeMessageExecutors/DisassociateRequestExecutor.cs
+++ b/FakeXrmEasy/FakeMessageExecutors/DisassociateRequestExecutor.cs
@@ -40,7 +40,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             foreach (var relatedEntity in disassociateRequest.RelatedEntities)
             {
-                var query = new QueryExpression(relationShipName)
+                var query = new QueryExpression(relationShip.IntersectEntity)
                 {
                     ColumnSet = new ColumnSet(true),
                     Criteria = new FilterExpression(LogicalOperator.And)
@@ -55,7 +55,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
                 if (results.Entities.Count == 1)
                 {
-                    service.Delete(relationShipName, results.Entities.First().Id);
+                    service.Delete(relationShip.IntersectEntity, results.Entities.First().Id);
                 }
             }
 

--- a/FakeXrmEasy/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy/XrmFakedContext.Crud.cs
@@ -191,7 +191,7 @@ namespace FakeXrmEasy
         #region Other protected methods
         protected void EnsureEntityNameExistsInMetadata(string sEntityName)
         {
-			if(Relationships.Values.Any(value => new[]{value.Entity1LogicalName, value.Entity2LogicalName}.Contains(sEntityName, StringComparer.InvariantCultureIgnoreCase)))
+			if(Relationships.Values.Any(value => new[]{value.Entity1LogicalName, value.Entity2LogicalName, value.IntersectEntity}.Contains(sEntityName, StringComparer.InvariantCultureIgnoreCase)))
 			{
 				return;
 			}


### PR DESCRIPTION
Hey @jordimontana82,

as I suspected yesterday, the intersect entity schema name was not used as it should have been.
I fixed that and changed the test request to look exactly like the MS examples, works as expected now.