### PR TITLE
Added fix for natural joins 

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/AssociateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/AssociateRequestExecutor.cs
@@ -17,6 +17,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
         public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
         {
             var associateRequest = request as AssociateRequest;
+            var service = ctx.GetFakedOrganizationService();
 
             if (associateRequest == null)
             {
@@ -47,8 +48,9 @@ namespace FakeXrmEasy.FakeMessageExecutors
                         }
                 };
 
-                association.Id = Guid.NewGuid();
-                ctx.AddEntity(association);
+                service.Create(association);
+
+
             }
 
             return new AssociateResponse ();

--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -133,6 +133,15 @@ namespace FakeXrmEasy
                                                             .JoinAttributes(innerEl, le.Columns, leAlias));
 
                     break;
+                case JoinOperator.Natural:
+                    query = query.Join(inner,
+                                    outerKey => outerKey.KeySelector(le.LinkFromAttributeName),
+                                    innerKey => innerKey.KeySelector(le.LinkToAttributeName),
+                                    (outerEl, innerEl) => outerEl
+                                                            .ProjectAttributes(previousColumnSet, context)
+                                                            .JoinAttributes(innerEl, le.Columns, leAlias));
+
+                    break;
                 case JoinOperator.LeftOuter:
                     query = query.GroupJoin(inner,
                                     outerKey => outerKey.KeySelector(le.LinkFromAttributeName),
@@ -145,6 +154,8 @@ namespace FakeXrmEasy
 
 
                     break;
+                default:
+                    throw new PullRequestException(string.Format("The join operator {0} is currently not supported. Feel free to implement and send a PR.", le.JoinOperator));
 
             }
 


### PR DESCRIPTION
Hey @jordimontana82,

Changes in short:
- Natural joins are supported, however processed identical to inner joins
- Throw pull request exception if join type is not supported.

Do you think you could release a new NuGet package soon?
Current package does not include XrmFakedRelationship somehow.

Kind Regards,
Florian