### PR TITLE
Added test that reveals possible bug while querying for entities

### DIFF
--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestCreate.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestCreate.cs
@@ -7,6 +7,8 @@ using FakeXrmEasy;
 using Microsoft.Xrm.Sdk.Query;
 
 using System.Collections.Generic;
+using System.Reflection;
+using Crm;
 using Microsoft.Xrm.Sdk;
 
 namespace FakeXrmEasy.Tests
@@ -62,9 +64,33 @@ namespace FakeXrmEasy.Tests
             Assert.True(context.Data["account"].Count == 1);
         }
 
+        [Fact]
+        public void When_Querying_Using_LinQ_Results_Should_Appear()
+        {
+            var context = new XrmFakedContext();
 
-        
+            var account = new Account
+            {
+                Id = Guid.NewGuid()
+            };
 
-        
+            var contact = new Contact
+            {
+                Id = Guid.NewGuid(),
+                Attributes = new AttributeCollection
+                {
+                    { "accountid", account.ToEntityReference() }
+                }
+            };
+
+            context.Initialize(new Entity[] { account, contact });
+
+            var contactResult = context.CreateQuery<Contact>().SingleOrDefault(con => con.Id == contact.Id);
+            Assert.NotNull(contactResult);
+        }
+
+
+
+
     }
 }


### PR DESCRIPTION
Hey @jordimontana82,

I found a case where you add an entity to the context, but querying using Linq fails.
When specifying a proxy types assembly, the tests pass, but I think if the entities are present in the context, it should also work without proxy types assembly.
I would like to add a fix, what do you think?

Kind Regards,
Florian