### PR TITLE
Added executors for create and delete requests

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/CreateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/CreateRequestExecutor.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class CreateRequestExecutor : IFakeMessageExecutor
+    {
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is CreateRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var createRequest = (CreateRequest)request;
+            
+            var service = ctx.GetFakedOrganizationService();
+
+            service.Create(createRequest.Target);
+
+            return new CreateResponse();
+        }
+    }
+}

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/DeleteRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/DeleteRequestExecutor.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class DeleteRequestExecutor : IFakeMessageExecutor
+    {
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is DeleteRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var deleteRequest = (DeleteRequest)request;
+
+            var target = deleteRequest.Target;
+
+            if (target == null)
+            {
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), "Can not delete without target");
+            }
+
+            var service = ctx.GetFakedOrganizationService();
+            service.Delete(target.LogicalName, target.Id);
+
+            return new DeleteResponse();
+        }
+    }
+}

--- a/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
+++ b/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
@@ -11,6 +11,8 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EntityExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\AssociateRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\CreateRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\DeleteRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\DisassociateRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\IFakeMessageExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveAttributeRequestExecutor.cs" />

--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -63,7 +63,9 @@ namespace FakeXrmEasy
             AddFakeMessageExecutor<SetStateRequest>(new SetStateRequestExecutor());
             AddFakeMessageExecutor<AssociateRequest>(new AssociateRequestExecutor());
             AddFakeMessageExecutor<DisassociateRequest>(new DisassociateRequestExecutor());
+            AddFakeMessageExecutor<CreateRequest>(new CreateRequestExecutor());
             AddFakeMessageExecutor<UpdateRequest>(new UpdateRequestExecutor());
+            AddFakeMessageExecutor<DeleteRequest>(new DeleteRequestExecutor());
 
             Relationships = new Dictionary<string, XrmFakedRelationship>();
         }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestDelete.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestDelete.cs
@@ -7,8 +7,11 @@ using FakeXrmEasy;
 using Microsoft.Xrm.Sdk.Query;
 
 using System.Collections.Generic;
+using System.Reflection;
 using Microsoft.Xrm.Sdk;
 using System.ServiceModel;
+using Crm;
+using Microsoft.Xrm.Sdk.Client;
 
 namespace FakeXrmEasy.Tests
 {
@@ -79,6 +82,33 @@ namespace FakeXrmEasy.Tests
             Assert.True(context.Data["account"].Count == 0);
         }
 
-        
+        [Fact]
+        public void When_Deleting_Using_Organization_Context_Record_Should_Be_Deleted()
+        {
+            var context = new XrmFakedContext();
+            context.ProxyTypesAssembly = Assembly.GetAssembly(typeof(Account));
+
+            var account = new Account() { Id = Guid.NewGuid(), Name = "Super Great Customer", AccountNumber = "69" };
+
+            var service = context.GetFakedOrganizationService();
+
+            using (var ctx = new OrganizationServiceContext(service))
+            {
+                ctx.AddObject(account);
+                ctx.SaveChanges();
+            }
+
+            Assert.NotNull(service.Retrieve(Account.EntityLogicalName, account.Id, new ColumnSet(true)));
+
+            using (var ctx = new OrganizationServiceContext(service))
+            {
+                ctx.Attach(account);
+                ctx.DeleteObject(account);
+                ctx.SaveChanges();
+
+                var retrievedAccount = ctx.CreateQuery<Account>().SingleOrDefault(acc => acc.Id == account.Id);
+                Assert.Null(retrievedAccount);
+            }
+        }
     }
 }


### PR DESCRIPTION
Hey Jordi,

I implemented the create and delete requests, so that the organization context can now be used pretty universally.
This resolves #32.

Kind Regards,
Florian