### PR TITLE
Changed FakeExecute: Prefer execution mocks over fake message executors

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -210,13 +210,13 @@ namespace FakeXrmEasy
                 .ReturnsLazily((OrganizationRequest req) =>
                 {
 
+                    if (context.ExecutionMocks.ContainsKey(req.GetType()))
+                    {
+                        return context.ExecutionMocks[req.GetType()].Invoke(req);
+                    }
                     if (context.FakeMessageExecutors.ContainsKey(req.GetType()))
                     {
                         return context.FakeMessageExecutors[req.GetType()].Execute(req, context);
-                    }
-                    else if (context.ExecutionMocks.ContainsKey(req.GetType()))
-                    {
-                        return context.ExecutionMocks[req.GetType()].Invoke(req);
                     }
 
                     throw PullRequestException.NotImplementedOrganizationRequest(req.GetType());


### PR DESCRIPTION
Hey @jordimontana82,

I had an issue where my plugin used a RetrieveAttributeRequest.
There is a FakeMessageExecutor for RetrieveAttributeRequest, which throws a PullRequestException when executing.
I changed the order, in which FakeExecute searches for the implementation to first look for Execution Mocks, to give users the ability to override default behaviours.
In addition to that: I think we should not make the execution mocks obsolete, since adding an execution mock with a lambda expression is much more convenient than the FakeMessageExecutor.

Kind Regards,
Florian