### PR TITLE
Fixed passing of 2015 constant to build target for crm 2016

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -107,7 +107,7 @@ Target "BuildFakeXrmEasy.2015" (fun _->
 
 Target "BuildFakeXrmEasy.2016" (fun _->
     let properties =
-        [ ("DefineConstants", "FAKE_XRM_EASY_2015") ]
+        [ ("DefineConstants", "FAKE_XRM_EASY_2016") ]
     !! @"FakeXrmEasy.2016\*.csproj"
       |> MSBuild FakeXrmEasy2016BuildDir "Rebuild" (properties)
       |> Log "Build - Output: "


### PR DESCRIPTION
Hey @jordimontana82,

the current release hides the ExecuteTransactionExecutor, since the build script passes the fake_xrm_easy_2015 constant instead of the 2016 one in the 2016 target.
With this fix, the ExecuteTransactionExecutor is compiled in the 2016 package.

Kind Regards,
Florian