### PR TITLE
Changed AssemblyInfo target to use correct path

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -77,9 +77,10 @@ Target "BuildVersions" (fun _ ->
     SetBuildNumber nugetVersion
 )
 Target "AssemblyInfo" (fun _ ->
-    BulkReplaceAssemblyInfoVersions "src/" (fun f ->
+    BulkReplaceAssemblyInfoVersions "." (fun f ->
                                               {f with
                                                   AssemblyVersion = asmVersion
+                                                  AssemblyFileVersion = asmVersion
                                                   AssemblyInformationalVersion = asmInfoVersion})
 )
 


### PR DESCRIPTION
Hi Jordi,

as we found out, the assemblies contained in the NuGet packages don't match the package version, i.e. FakeXrmEasy 1.10.0 contains assemblies with version 1.9.1.
There is a build target called "AssemblyInfo", which is responsible for this and which searched for AssemblyInfos in the wrong path.
I changed it to search in the project root dir, should work now.

Kind Regards,
Florian 