### PR TITLE
include primary key when joining attributes

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -141,7 +141,8 @@ namespace FakeXrmEasy.Extensions
             if (otherEntity == null) return e; //Left Join where otherEntity was not matched
 
             if (columnSet.AllColumns)
-            {
+            {   
+                e[alias + "." + alias + "id"] = new AliasedValue(alias, alias + "id", otherEntity.Id); // add the primary key
                 foreach (var attKey in otherEntity.Attributes.Keys)
                 {
                     e[alias + "." + attKey] = new AliasedValue(alias, attKey, otherEntity[attKey]);
@@ -172,6 +173,7 @@ namespace FakeXrmEasy.Extensions
             foreach (var otherEntity in otherEntities) { 
                 if (columnSet.AllColumns)
                 {
+                    e[alias + "." + alias + "id"] = new AliasedValue(alias, alias + "id", otherEntity.Id); // add the primary key
                     foreach (var attKey in otherEntity.Attributes.Keys)
                     {
                         e[alias + "." + attKey] = new AliasedValue(alias, attKey, otherEntity[attKey]);

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
@@ -339,10 +339,10 @@ namespace FakeXrmEasy.Tests
             var lastContact = result.LastOrDefault();
 
             //Contact 1 attributes = 3 + 5 (the extra five are the CreatedOn, ModifiedOn, CreatedBy, ModifiedBy + StateCode attributes generated automatically
-            //+ Attributes from the join(account) = 1 + 5
+            //+ Attributes from the join(account) = id + 1 + 5
 
-            Assert.True(firstContact.Attributes.Count == 3 + 1 + 5 * 2);
-            Assert.True(lastContact.Attributes.Count == 3 + 1 + 5 * 2);  //Contact 2
+            Assert.True(firstContact.Attributes.Count == 3 + 2 + 5 * 2);
+            Assert.True(lastContact.Attributes.Count == 3 + 2 + 5 * 2);  //Contact 2
         }
 
         [Fact]


### PR DESCRIPTION
#64 is still broken. The problem is JoinAttributes does not include the primary id key. I have added 

`e[alias + "." + alias + "id"] = new AliasedValue(alias, alias + "id", otherEntity.Id);`

in 2 places and also added test cases.