### PR TITLE
Added fake message executors, executors are discovered automatically

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/AssignRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/AssignRequestExecutor.cs
@@ -48,5 +48,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new AssignResponse();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof (AssignRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/AssociateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/AssociateRequestExecutor.cs
@@ -71,5 +71,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new AssociateResponse ();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(AssociateRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/CloseQuoteRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/CloseQuoteRequestExecutor.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class CloseQuoteRequestExecutor : IFakeMessageExecutor
+    {
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is CloseQuoteRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var closeRequest = request as CloseQuoteRequest;
+
+            if (closeRequest == null)
+            {
+                throw new Exception("You did not pass a CloseQuoteRequest");
+            }
+
+            var quoteClose = closeRequest.QuoteClose;
+
+            if (quoteClose == null)
+            {
+                throw new Exception("QuoteClose is mandatory");
+            }
+
+            var quoteId = quoteClose.GetAttributeValue<EntityReference>("quoteid");
+
+            if (quoteId == null)
+            {
+                throw new Exception("Quote ID is not set on QuoteClose, but is required");
+            }
+
+            var update = new Entity
+            {
+                Id = quoteId.Id,
+                LogicalName = "quote",
+                Attributes = new AttributeCollection
+                {
+                    { "statuscode", closeRequest.Status }
+                }
+            };
+
+            var service = ctx.GetOrganizationService();
+
+            service.Update(update);
+
+            return new CloseQuoteResponse();
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(CloseQuoteRequest);
+        }
+    }
+}

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/CreateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/CreateRequestExecutor.cs
@@ -27,5 +27,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
                 Results = new ParameterCollection { { "id", guid } }
             };
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(CreateRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/DeleteRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/DeleteRequestExecutor.cs
@@ -30,5 +30,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new DeleteResponse();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(DeleteRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/DisassociateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/DisassociateRequestExecutor.cs
@@ -61,5 +61,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new DisassociateResponse();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(DisassociateRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/ExecuteMultipleRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/ExecuteMultipleRequestExecutor.cs
@@ -86,5 +86,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return response;
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(ExecuteMultipleRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/ExecuteTransactionExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/ExecuteTransactionExecutor.cs
@@ -32,6 +32,11 @@ namespace FakeXrmEasy.FakeMessageExecutors
             }
             return response;
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(ExecuteTransactionRequest);
+        }
     }
 }
 #endif

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/IFakeMessageExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/IFakeMessageExecutor.cs
@@ -13,6 +13,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
     public interface IFakeMessageExecutor
     {
         bool CanExecute(OrganizationRequest request);
+        Type GetResponsibleRequestType();
         OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx);
     }
 

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/InsertOptionValueRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/InsertOptionValueRequestExecutor.cs
@@ -53,5 +53,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new InsertOptionValueResponse();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(InsertOptionValueRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/PublishXmlRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/PublishXmlRequestExecutor.cs
@@ -26,5 +26,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             };
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(PublishXmlRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveAttributeRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveAttributeRequestExecutor.cs
@@ -19,5 +19,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
         {
             throw PullRequestException.NotImplementedOrganizationRequest(request.GetType());
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(RetrieveAttributeRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveMultipleRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveMultipleRequestExecutor.cs
@@ -120,5 +120,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return sFormattedValue;
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(RetrieveMultipleRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/ReviseQuoteRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/ReviseQuoteRequestExecutor.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class ReviseQuoteRequestExecutor : IFakeMessageExecutor
+    {
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is ReviseQuoteRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var service = ctx.GetOrganizationService();
+
+            var reviseQuoteRequest = request as ReviseQuoteRequest;
+
+            if (reviseQuoteRequest == null)
+            {
+                throw new Exception("You did not pass a ReviseQuoteRequest!");
+            }
+
+            var oldQuoteId = reviseQuoteRequest.QuoteId;
+
+            if (oldQuoteId == Guid.Empty)
+            {
+                throw new Exception("QuoteId needs to be set!");
+            }
+
+            var oldQuote = service.Retrieve("quote", oldQuoteId, new ColumnSet(true));
+
+            var revisedQuote = new Entity
+            {
+                LogicalName = "quote",
+                Id = Guid.NewGuid()
+            };
+
+            var columnSet = reviseQuoteRequest.ColumnSet;
+            var quoteBlackList = new List<string> { "quoteid", "statuscode", "statecode", "createdon", "createdby" };
+
+            foreach (var attribute in oldQuote.Attributes)
+            {
+                if (quoteBlackList.Contains(attribute.Key))
+                {
+                    continue;
+                }
+
+                if (columnSet.AllColumns || columnSet.Columns.Contains(attribute.Key))
+                {
+                    revisedQuote[attribute.Key] = attribute.Value; 
+                }
+            }
+
+            service.Create(revisedQuote);
+
+            var quoteLines = service.RetrieveMultiple(new QueryExpression("quotedetail")
+            {
+                ColumnSet = new ColumnSet(true),
+                Criteria = new FilterExpression(LogicalOperator.And)
+                {
+                    Conditions = { new ConditionExpression("quoteid", ConditionOperator.Equal, oldQuote.ToEntityReference()) }
+                }
+            }).Entities.ToList();
+
+            foreach (var quoteDetail in quoteLines)
+            {
+                var revisedDetail = new Entity
+                {
+                    LogicalName = "quotedetail",
+                    Id = Guid.NewGuid(),
+                    Attributes = new AttributeCollection
+                    {
+                        { "quoteid", revisedQuote.ToEntityReference() }
+                    }
+                };
+
+                var quoteDetailBlackList = new List<string> { "quoteid", "quotedetailid", "createdon", "createdby" };
+
+                foreach (var attribute in quoteDetail.Attributes)
+                {
+                    if (quoteDetailBlackList.Contains(attribute.Key))
+                    {
+                        continue;
+                    }
+
+                    revisedDetail[attribute.Key] = attribute.Value;
+                }
+
+                service.Create(revisedDetail);
+            }
+
+            var response = new ReviseQuoteResponse();
+
+            revisedQuote = service.Retrieve(revisedQuote.LogicalName, revisedQuote.Id, new ColumnSet(true));
+
+            response.Results["Entity"] = revisedQuote;
+
+            return response;
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(ReviseQuoteRequest);
+        }
+    }
+}

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/SetStateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/SetStateRequestExecutor.cs
@@ -32,5 +32,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new SetStateResponse();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(SetStateRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/UpdateRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/UpdateRequestExecutor.cs
@@ -24,5 +24,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
             return new UpdateResponse();
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(UpdateRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/WhoAmIRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/WhoAmIRequestExecutor.cs
@@ -26,5 +26,10 @@ namespace FakeXrmEasy.FakeMessageExecutors
             };
             return response;
         }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(WhoAmIRequest);
+        }
     }
 }

--- a/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
+++ b/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\XmlExtensionsForFetchXml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\AssignRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\AssociateRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\CloseQuoteRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\CreateRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\DeleteRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\DisassociateRequestExecutor.cs" />
@@ -24,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\PublishXmlRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveAttributeRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveMultipleRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\ReviseQuoteRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\SetStateRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\UpdateRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\WhoAmIRequestExecutor.cs" />

--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -60,29 +60,14 @@ namespace FakeXrmEasy
             AttributeMetadata = new Dictionary<string, Dictionary<string, string>>();
             Data = new Dictionary<string, Dictionary<Guid, Entity>>();
             ExecutionMocks = new Dictionary<Type, ServiceRequestExecution>();
-            FakeMessageExecutors = new Dictionary<Type, IFakeMessageExecutor>();
             OptionSetValuesMetadata = new Dictionary<string, OptionSetMetadata>();
 
-            //Adding default execution fakes
-            AddFakeMessageExecutor<WhoAmIRequest>(new WhoAmIRequestExecutor());
-            AddFakeMessageExecutor<RetrieveMultipleRequest>(new RetrieveMultipleRequestExecutor());
-            AddFakeMessageExecutor<RetrieveAttributeRequest>(new RetrieveAttributeRequestExecutor());
-            AddFakeMessageExecutor<SetStateRequest>(new SetStateRequestExecutor());
-            AddFakeMessageExecutor<AssociateRequest>(new AssociateRequestExecutor());
-            AddFakeMessageExecutor<DisassociateRequest>(new DisassociateRequestExecutor());
-            AddFakeMessageExecutor<CreateRequest>(new CreateRequestExecutor());
-            AddFakeMessageExecutor<UpdateRequest>(new UpdateRequestExecutor());
-            AddFakeMessageExecutor<DeleteRequest>(new DeleteRequestExecutor());
-            AddFakeMessageExecutor<AssignRequest>(new AssignRequestExecutor());
-            AddFakeMessageExecutor<PublishXmlRequest>(new PublishXmlRequestExecutor());
-            AddFakeMessageExecutor<InsertOptionValueRequest>(new InsertOptionValueRequestExecutor());
-
-
-            AddFakeMessageExecutor<ExecuteMultipleRequest>(new ExecuteMultipleRequestExecutor());
-#if FAKE_XRM_EASY_2016
-            AddFakeMessageExecutor<ExecuteTransactionRequest>(new ExecuteTransactionExecutor());
-#endif
-
+            FakeMessageExecutors = Assembly.GetExecutingAssembly()
+                .GetTypes()
+                .Where(t => t.GetInterfaces().Contains(typeof (IFakeMessageExecutor)))
+                .Select(t => Activator.CreateInstance(t) as IFakeMessageExecutor)
+                .ToDictionary(t => t.GetResponsibleRequestType(), t => t);
+            
             Relationships = new Dictionary<string, XrmFakedRelationship>();
         }
 

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/CloseQuoteRequestTests/CloseQuoteRequestTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/CloseQuoteRequestTests/CloseQuoteRequestTests.cs
@@ -1,0 +1,65 @@
+﻿using FakeXrmEasy.FakeMessageExecutors;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.FakeContextTests.CloseQuoteRequestTests
+{
+    public class CloseQuoteRequestTests
+    {
+        [Fact]
+        public void When_can_execute_is_called_with_an_invalid_request_result_is_false()
+        {
+            var executor = new CloseQuoteRequestExecutor();
+            var anotherRequest = new RetrieveMultipleRequest();
+            Assert.False(executor.CanExecute(anotherRequest));
+        }
+
+        [Fact]
+        public void Should_Change_Status_When_Closing()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var quote = new Entity
+            {
+                LogicalName = "quote",
+                Id = Guid.NewGuid(),
+                Attributes = new AttributeCollection
+                {
+                    {"statuscode", new OptionSetValue(0)}
+                }
+            };
+
+            context.Initialize(new []
+            {
+                quote
+            });
+
+            var executor = new CloseQuoteRequestExecutor();
+
+            var req = new CloseQuoteRequest {
+                QuoteClose = new Entity
+                {
+                    Attributes = new AttributeCollection
+                    {
+                        { "quoteid", quote.ToEntityReference() }
+                    }
+                },
+                Status = new OptionSetValue(1)
+            };
+
+            Assert.DoesNotThrow(() => executor.Execute(req, context));
+
+            quote = service.Retrieve("quote", quote.Id, new ColumnSet(true));
+
+            Assert.Equal(new OptionSetValue(1), quote.GetAttributeValue<OptionSetValue>("statuscode"));
+        }
+    }
+}

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextMockTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextMockTests.cs
@@ -94,6 +94,11 @@ namespace FakeXrmEasy.Tests.FakeContextTests
                 return request is RetrieveEntityRequest;
             }
 
+            public Type GetResponsibleRequestType()
+            {
+                return typeof(RetrieveEntityRequest);
+            }
+
             public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
             {
                 return new RetrieveEntityResponse { ResponseName = "Successful" };

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/ReviseQuoteRequestTests/ReviseQuoteRequestTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/ReviseQuoteRequestTests/ReviseQuoteRequestTests.cs
@@ -1,0 +1,97 @@
+﻿using FakeXrmEasy.FakeMessageExecutors;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ServiceModel;
+using System.Text;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.FakeContextTests.ReviseQuoteRequestTests
+{
+    public class ReviseQuoteRequestTests
+    {
+        [Fact]
+        public void When_can_execute_is_called_with_an_invalid_request_result_is_false()
+        {
+            var executor = new ReviseQuoteRequestExecutor();
+            var anotherRequest = new RetrieveMultipleRequest();
+
+            Assert.False(executor.CanExecute(anotherRequest));
+        }
+
+        [Fact]
+        public void Should_Create_New_Quote_With_Lines_When_Revisioning()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var quote = new Entity
+            {
+                LogicalName = "quote",
+                Id = Guid.NewGuid(),
+                Attributes = new AttributeCollection
+                {
+                    {"statuscode", new OptionSetValue(1)},
+                    {"name", "Adventure Quote"}
+                }
+            };
+
+            var quoteDetail = new Entity
+            {
+                LogicalName = "quotedetail",
+                Id = Guid.NewGuid(),
+                Attributes = new AttributeCollection
+                {
+                    {"quoteid", quote.ToEntityReference() },
+                    {"extendedamount", new Money(1000m) }
+                }
+            };
+
+            context.Initialize(new[]
+            {
+                quote, quoteDetail
+            });
+
+            var executor = new ReviseQuoteRequestExecutor();
+
+            var req = new ReviseQuoteRequest
+            {
+                ColumnSet = new ColumnSet(true),
+                QuoteId = quote.Id
+            };
+
+            Assert.DoesNotThrow(() => executor.Execute(req, context));
+
+            quote = service.RetrieveMultiple(new QueryExpression("quote")
+            {
+                ColumnSet = new ColumnSet(true),
+                Criteria = new FilterExpression(LogicalOperator.And)
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression("quoteid", ConditionOperator.NotEqual, quote.Id)
+                    }
+                }
+            }).Entities.SingleOrDefault();
+
+            Assert.NotNull(quote);
+            Assert.Equal("Adventure Quote", quote.GetAttributeValue<string>("name"));
+
+            var quoteLines = service.RetrieveMultiple(new QueryExpression("quotedetail")
+            {
+                ColumnSet = new ColumnSet(true),
+                Criteria = new FilterExpression(LogicalOperator.And)
+                {
+                    Conditions = { new ConditionExpression("quoteid", ConditionOperator.Equal, quote.ToEntityReference()) }
+                }
+            }).Entities.ToList();
+
+            Assert.Equal(1, quoteLines.Count);
+            Assert.Equal(new Money(1000m), quoteLines.Single().GetAttributeValue<Money>("extendedamount"));
+        }
+    }
+}

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CodeActivitiesForTesting\CreateTaskActivity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\AssignRequestTests\AssignRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\AssociateRequestTests\AssociateRequestTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\CloseQuoteRequestTests\CloseQuoteRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\DeleteRequestTests\DeleteRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\ExecuteMultipleRequestTests\ExecuteMultipleRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\ExecuteTransationTests\ExecuteTransactionTests.cs" />
@@ -43,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\QueryByAttribute\QueryByAttributeTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\RetrieveAttributeRequestTests\RetrieveAttributeRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\RetrieveMultiple\QueryLinkEntityTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\ReviseQuoteRequestTests\ReviseQuoteRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\SetStateRequestTests\SetStateRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\ConditionExpressionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\FakeContextTestFormattedValues.cs" />


### PR DESCRIPTION
Hey @jordimontana82,

I added FakeMessageExecutors for CloseQuoteRequest and ReviseQuoteRequests.

I also found that it might be an advantage if all FakeMessageExecutors were discovered automatically on initialization, so that we don't forget to add new executors.
We should not get issues with version dependent executors like the ExecuteTransactionRequestExecutor, as it is not even available in older assemblies as far as I can tell.

I hope you like it. If you don't want the changes besides the new executors, just give me a note and I will exclude everything else.

Kind Regards,
Florian