### PR TITLE
Fixed OnOrBefore not including records with time on same day.

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -435,9 +435,8 @@ namespace FakeXrmEasy
                                TranslateConditionExpressionEqual(context, c, getNonBasicValueExpr, containsAttributeExpression),
                                TranslateConditionExpressionGreaterThan(c, getNonBasicValueExpr, containsAttributeExpression));
                 case ConditionOperator.OnOrBefore:
-                    return Expression.Or(
-                                TranslateConditionExpressionEqual(context, c, getNonBasicValueExpr, containsAttributeExpression),
-                                TranslateConditionExpressionLessThan(c, getNonBasicValueExpr, containsAttributeExpression));
+                    SetConditionValueToNextDay(c);
+                    return TranslateConditionExpressionLessThan(c, getNonBasicValueExpr, containsAttributeExpression);
 
                 case ConditionOperator.Between:
                     if(c.CondExpression.Values.Count != 2)
@@ -462,6 +461,18 @@ namespace FakeXrmEasy
 
             }
         }
+
+        protected static void SetConditionValueToNextDay(TypedConditionExpression c)
+        {
+            if (c == null || c.CondExpression == null || c.CondExpression.Values.Count < 1)
+                return;
+
+            var originalDate = c.CondExpression.Values[0] as DateTime?;
+
+            if (originalDate != null)
+                c.CondExpression.Values[0] = originalDate.Value.Date.AddDays(1);
+        }
+
         protected static Expression GetAppropiateTypedValue(object value)
         {
             //Basic types conversions

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/ConditionOperatorTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/ConditionOperatorTests.cs
@@ -820,16 +820,19 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
             var ct1 = new Contact() { Id = Guid.NewGuid(), Anniversary = date }; //Should be returned
             var ct2 = new Contact() { Id = Guid.NewGuid(), Anniversary = date.AddDays(-1) }; //Should be returned
             var ct3 = new Contact() { Id = Guid.NewGuid(), Anniversary = date.AddDays(1) }; //Shouldnt
-            ctx.Initialize(new[] { ct1, ct2, ct3 });
+            var ct4 = new Contact() {Id = Guid.NewGuid(), Anniversary = date.AddHours(4)}; // Should be returned
+            ctx.Initialize(new[] { ct1, ct2, ct3, ct4 });
             var service = ctx.GetFakedOrganizationService();
 
             var collection = service.RetrieveMultiple(new FetchExpression(fetchXml));
 
-            Assert.Equal(2, collection.Entities.Count);
+            Assert.Equal(3, collection.Entities.Count);
             var retrievedDateFirst = collection.Entities[0]["anniversary"] as DateTime?;
             var retrievedDateSecond = collection.Entities[1]["anniversary"] as DateTime?;
+            var retrieveDateThird = collection.Entities[2]["anniversary"] as DateTime?;
             Assert.Equal(23, retrievedDateFirst.Value.Day);
             Assert.Equal(22, retrievedDateSecond.Value.Day);
+            Assert.Equal(4, retrieveDateThird.Value.Hour);
         }
 
         [Fact]

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/ConditionExpressionTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/ConditionExpressionTests.cs
@@ -309,5 +309,35 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests
             Assert.True(ec.Entities.Count == 2);
         }
 
+        [Fact]
+        public void When_executing_a_query_expression_with_OnOrBefore_right_result_is_returned()
+        {
+            var fakedContext = new XrmFakedContext();
+            var fakedService = fakedContext.GetFakedOrganizationService();
+
+            var entity = new Entity("entity1")
+            {
+                Id = Guid.NewGuid(),
+                ["startTime"] = new DateTime(2016, 2, 1, 5, 0, 0) // 2016/2/1 set in EST timezone
+            };
+
+            var query = new QueryExpression
+            {
+                EntityName = "entity1",
+                Criteria = new FilterExpression
+                {
+                    Conditions =
+                    {
+                        new ConditionExpression("startTime", ConditionOperator.OnOrBefore, new DateTime(2016, 2, 1))
+                    }
+                }
+            };
+
+            fakedContext.Initialize(new[] {entity});
+            var result = fakedService.RetrieveMultiple(query);
+
+            Assert.Equal(1, result.Entities.Count);
+        }
+
     }
 }


### PR DESCRIPTION
OnOrBefore is not including records where the day is the same as the specified value and the date has a time component.

For example, if I set a date field to the day 2/1/2017 and I am in the timezone EST, then the stored value will be 2/1/2017 5:00 UTC. When I execute a query with the operator OnOrBefore and the value 2/1/2017 then this date should be included.