### PR TITLE
Additional Fix for issue 114. Crm contxt generated using Xrm.Client i…

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -138,7 +138,11 @@ namespace FakeXrmEasy.Extensions
             if (type == typeof(string))
                 return new string((attributeValue as string).ToCharArray());
 
-            else if (type == typeof(EntityReference))
+            else if (type == typeof(EntityReference)
+                    #if FAKE_XRM_EASY 
+                            || type == typeof(Microsoft.Xrm.Client.CrmEntityReference) 
+                    #endif 
+                    )
             {
                 var original = (attributeValue as EntityReference);
                 var clone = new EntityReference(original.LogicalName, original.Id);

--- a/FakeXrmEasy.Shared/Extensions/XmlExtensionsForFetchXml.cs
+++ b/FakeXrmEasy.Shared/Extensions/XmlExtensionsForFetchXml.cs
@@ -480,13 +480,21 @@ namespace FakeXrmEasy.Extensions.FetchXml
 
             else if (t == typeof(Guid)
                 || t == typeof(Guid?)
-                || t == typeof(EntityReference))
+                || t == typeof(EntityReference)
+                #if FAKE_XRM_EASY
+                    || t == typeof(Microsoft.Xrm.Client.CrmEntityReference) 
+                #endif
+                )
             {
                 Guid gValue = Guid.Empty;
 
                 if (Guid.TryParse(value, out gValue))
                 {
-                    if (t == typeof(EntityReference))
+                    if (t == typeof(EntityReference)
+                    #if FAKE_XRM_EASY
+                    || t == typeof(Microsoft.Xrm.Client.CrmEntityReference) 
+                    #endif
+                        )
                     {
                         return new EntityReference() { Id = gValue };
                     }

--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -595,7 +595,12 @@ namespace FakeXrmEasy
         {
             if(attributeType != null)
                 {
-                    if(attributeType == typeof(Guid) || attributeType == typeof(EntityReference))
+
+                    #if FAKE_XRM_EASY
+                    if (attributeType == typeof(Microsoft.Xrm.Client.CrmEntityReference))
+                            return GetAppropiateCastExpressionBasedGuid(input);
+                    #endif
+                    if (attributeType == typeof(Guid) || attributeType == typeof(EntityReference))
                         return GetAppropiateCastExpressionBasedGuid(input);
                     if (attributeType == typeof(int) || attributeType == typeof(Nullable<int>) || attributeType.IsOptionSet() )
                         return GetAppropiateCastExpressionBasedOnInt(input);

--- a/FakeXrmEasy.Shared/XrmOrderByAttributeComparer.cs
+++ b/FakeXrmEasy.Shared/XrmOrderByAttributeComparer.cs
@@ -25,7 +25,11 @@ namespace FakeXrmEasy
                 OptionSetValue attributeValueB = (OptionSetValue)(objectB);
                 return attributeValueA.Value.CompareTo(attributeValueB.Value);
             }
-            else if (attributeType == typeof(EntityReference))
+            else if (attributeType == typeof(EntityReference)
+                #if FAKE_XRM_EASY
+                    || attributeType == typeof(Microsoft.Xrm.Client.CrmEntityReference) 
+                #endif
+                )
             {
                 // Name might well be Null in an entity reference?
                 EntityReference entityRefA = (EntityReference)objectA;


### PR DESCRIPTION
…s using Microsoft.Xrm.Client.CrmEntityReference instead of EntityRefernce object. Fixed casting issue.