### PR TITLE
Fix for #147

### DIFF
--- a/FakeXrmEasy.365/FakeXrmEasy.365.csproj
+++ b/FakeXrmEasy.365/FakeXrmEasy.365.csproj
@@ -25,7 +25,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;FAKE_XRM_EASY_365</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/ExecuteMultipleRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/ExecuteMultipleRequestExecutor.cs
@@ -40,13 +40,14 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
                 try
                 {
-                    service.Execute(executeRequest);
+                    OrganizationResponse resp = service.Execute(executeRequest);
 
                     if (executeMultipleRequest.Settings.ReturnResponses)
                     {
                         response.Responses.Add(new ExecuteMultipleResponseItem
                         {
-                            RequestIndex = i
+                            RequestIndex = i,
+                            Response = resp
                         });
                     }
                 }

--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -84,10 +84,12 @@ namespace FakeXrmEasy
                 }
                 catch { }
             }
+#if FAKE_XRM_EASY_2015 || FAKE_XRM_EASY_2016 || FAKE_XRM_EASY_365
             else if (attributeInfo.PropertyType.FullName.StartsWith("System.Nullable"))
             {
                 return attributeInfo.PropertyType.GenericTypeArguments[0];
             }
+#endif
 
             return attributeInfo.PropertyType;
         }

--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -65,9 +65,28 @@ namespace FakeXrmEasy
                 .Where(pi => (pi.GetCustomAttributes(typeof(AttributeLogicalNameAttribute), true)[0] as AttributeLogicalNameAttribute).LogicalName.Equals(sAttributeName))
                 .FirstOrDefault();
 
-            if(attributeInfo == null)
+            if (attributeInfo == null)
             {
                 throw new Exception(string.Format("XrmFakedContext.FindReflectedAttributeType: Attribute {0} not found for type {1}", sAttributeName, earlyBoundType.ToString()));
+            }
+            else if (attributeInfo.PropertyType.FullName.EndsWith("Enum"))
+            {
+                return typeof(System.Int32);
+            }
+            else if (!attributeInfo.PropertyType.FullName.StartsWith("System."))
+            {
+                try
+                {
+                    var inst = Activator.CreateInstance(attributeInfo.PropertyType);
+
+                    if (inst is Entity)
+                        return typeof(EntityReference);
+                }
+                catch { }
+            }
+            else if (attributeInfo.PropertyType.FullName.StartsWith("System.Nullable"))
+            {
+                return attributeInfo.PropertyType.GenericTypeArguments[0];
             }
 
             return attributeInfo.PropertyType;


### PR DESCRIPTION
I have a custom Entity generator, I'm not using crmsvcutil. This is to provide custom functionality in my entities which crmsvcutil will not provide, among other things I don't return EntityReferences I return full populated Entities, since in 99% of cases (for me anyway) I want the full Entity, and not just a reference, returning the full Entity saves a lot of repetitive code to fetch the Entity from CRM. The same goes for related entity data.

My Entities obviously inherit from Xrm.Sdk.Entity and have the same basic structure as the crmsvcutil Entities, otherwise nothing would work with FakeXrmEasy! The main difference are the types of the Properties, they are all still decorated with the same AttributeLogicalNameAttribute.

However, in the case of the FakeXrm Query handler, obviously some adjustments need to be made. In the change I've made, the first if block is for Enums, which sit on top of OptionSets, therefore anything which is an Enum needs to be translated to an Int32.

The second if block handles anything which is not a System Type, and tries to instantiate it and see if it is an Entity, if it is an Entity then really an EntityReference needs to be returned for the purpose of the Query.

The third if block looks to see if this is a Nullable - since crmsvcutil generates Nullables too, I would have thought that this block is necessary for crmsvcutil generated code - all your tests pass without this block present, but mine do not where a nullable property is included in the ConditionExpression of a Query.

I understand that as it stands these, at least the first and second if blocks are going to be specific to my code, however, returning an Entity instead of an EntityReference seems like a reasonable thing to be doing with Early-Bound entities.

Returning something with a name ending in Enum when dealing with OptionSets is a bit more custom but again seems pretty reasonable.

I'll leave it with you if you think it's fit to include these changes in your master repo, if not then I'll maintain them in my fork.