### PR TITLE
FakeDelete should use the same entity validity checking as FakeRetrie…

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -155,12 +155,22 @@ namespace FakeXrmEasy
                         throw new InvalidOperationException("The id must not be empty.");
                     }
 
+                    // Don't fail with invalid operation exception, if no record of this entity exists, but entity is known
                     if (!context.Data.ContainsKey(entityName))
-                        throw new InvalidOperationException(string.Format("The entity logical name {0} is not valid.", entityName));
+                    {
+                        if (context.ProxyTypesAssembly == null)
+                        {
+                            throw new InvalidOperationException(string.Format("The entity logical name {0} is not valid.", entityName));
+                        }
+
+                        if (!context.ProxyTypesAssembly.GetTypes().Any(type => context.FindReflectedType(entityName) != null))
+                        {
+                            throw new InvalidOperationException(string.Format("The entity logical name {0} is not valid.", entityName));
+                        }
+                    }
 
                     //Entity logical name exists, so , check if the requested entity exists
-                    if (context.Data[entityName] != null
-                        && context.Data[entityName].ContainsKey(id))
+                    if (context.Data.ContainsKey(entityName) && context.Data[entityName] != null && context.Data[entityName].ContainsKey(id))
                     {
                         //Entity found => return only the subset of columns specified or all of them
                         context.Data[entityName].Remove(id);

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestDelete.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestDelete.cs
@@ -64,6 +64,35 @@ namespace FakeXrmEasy.Tests
         }
 
         [Fact]
+        public void When_delete_is_invoked_with_non_existing_entity_and_nothing_has_been_initalised_an_exception_is_thrown()
+        {
+            var context = new XrmFakedContext();
+
+            //Initialize the context with a single entity
+            var nonExistingGuid = Guid.NewGuid();
+            
+            var service = context.GetFakedOrganizationService();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Delete("account", nonExistingGuid));
+            Assert.Equal(ex.Message.ToLower(), "the entity logical name account is not valid.");
+        }
+
+        [Fact]
+        public void When_delete_is_invoked_with_non_existing_entity_and_nothing_has_been_initalised_using_proxytypes_assembly_an_exception_is_thrown()
+        {
+            var context = new XrmFakedContext();
+            context.ProxyTypesAssembly = Assembly.GetAssembly(typeof(Account));
+
+            //Initialize the context with a single entity
+            var nonExistingGuid = Guid.NewGuid();
+
+            var service = context.GetFakedOrganizationService();
+
+            var ex = Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Delete("account", nonExistingGuid));
+            Assert.Equal(ex.Message, string.Format("account with Id {0} Does Not Exist", nonExistingGuid));
+        }
+
+        [Fact]
         public void When_delete_is_invoked_with_an_existing_entity_that_entity_is_delete_from_the_context()
         {
             var context = new XrmFakedContext();


### PR DESCRIPTION
FakeDelete at the moment does not do the same entity validity checking as FakeRetrieve, and therefore returns an erroneous error when a delete is run and no data has been initialised. This commit fixes that so that FakeDelete uses the same logic as FakeRetrieve.