### PR TITLE
PrimaryKey attribute should be populated if it doesn't exist

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -220,9 +220,7 @@ namespace FakeXrmEasy
         {
             //Validate primary key for dynamic entities
             var primaryKey = string.Format("{0}id", e.LogicalName);
-            if (ProxyTypesAssembly == null &&
-                !e.GetType().IsSubclassOf(typeof(Entity)) &&
-                !e.Attributes.ContainsKey(primaryKey))
+            if (!e.Attributes.ContainsKey(primaryKey))
             {
                 e[primaryKey] = e.Id;
             }
@@ -277,20 +275,16 @@ namespace FakeXrmEasy
             if (e.Id == Guid.Empty)
             {
                 e.Id = Guid.NewGuid(); //Add default guid if none present
-
-                ValidateEntity(e);
-
-                //Hack for Dynamic Entities where the Id property doesn't populate the "entitynameid" primary key
-                if (!e.GetType().IsSubclassOf(typeof(Entity)))
-                {
-                    var primaryKeyAttribute = string.Format("{0}id", e.LogicalName);
-                    e[primaryKeyAttribute] = e.Id;
-                }
             }
-            else
+
+            //Hack for Dynamic Entities where the Id property doesn't populate the "entitynameid" primary key
+            var primaryKeyAttribute = string.Format("{0}id", e.LogicalName);
+            if (!e.GetType().IsSubclassOf(typeof(Entity)) && !e.Attributes.ContainsKey(primaryKeyAttribute))
             {
-                ValidateEntity(e);
+                e[primaryKeyAttribute] = e.Id;
             }
+
+            ValidateEntity(e);
 
             //Create specific validations
             if (e.Id != Guid.Empty && Data.ContainsKey(e.LogicalName) &&

--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -279,7 +279,7 @@ namespace FakeXrmEasy
 
             //Hack for Dynamic Entities where the Id property doesn't populate the "entitynameid" primary key
             var primaryKeyAttribute = string.Format("{0}id", e.LogicalName);
-            if (!e.GetType().IsSubclassOf(typeof(Entity)) && !e.Attributes.ContainsKey(primaryKeyAttribute))
+            if (!e.Attributes.ContainsKey(primaryKeyAttribute))
             {
                 e[primaryKeyAttribute] = e.Id;
             }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestCreate.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestCreate.cs
@@ -181,6 +181,26 @@ namespace FakeXrmEasy.Tests
         }
 
         [Fact]
+        public void When_creating_a_record_using_early_bound_entities_and_proxytypes_primary_key_should_be_populated()
+        {
+            var context = new XrmFakedContext();
+            context.ProxyTypesAssembly = Assembly.GetAssembly(typeof(Contact));
+            var c = new Contact();
+            c.Id = Guid.NewGuid();
+
+            IOrganizationService service = context.GetFakedOrganizationService();
+
+            context.Initialize(new List<Entity>() { c });
+
+            //Retrieve the record created
+            var contact = (from con in context.CreateQuery<Contact>()
+                           select con).FirstOrDefault();
+
+            Assert.True(contact.Attributes.ContainsKey("contactid"));
+            Assert.Equal(c.Id, contact["contactid"]);
+        }
+
+        [Fact]
         public void When_related_entities_are_used_without_relationship_info_exception_is_raised()
         {
             var ctx = new XrmFakedContext();


### PR DESCRIPTION
PrimaryKey attribute should be populated if it doesn't exist regardless of whether the entity is early bound or not or whether a ProxyTypes assembly is registered or not.