### PR TITLE
Update to FakeItEasy 3.2

### DIFF
--- a/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
+++ b/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
@@ -127,7 +127,9 @@
   <ItemGroup>
     <None Include="app.config" />
     <None Include="fakexrmeasy.snk" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>

--- a/FakeXrmEasy.2013/packages.config
+++ b/FakeXrmEasy.2013/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
   <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.Extensions" version="6.0.4.1" targetFramework="net40" />

--- a/FakeXrmEasy.2015/FakeXrmEasy.2015.csproj
+++ b/FakeXrmEasy.2015/FakeXrmEasy.2015.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -123,7 +123,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="fakexrmeasy.snk" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\FakeXrmEasy.Shared\FakeXrmEasy.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/FakeXrmEasy.2015/packages.config
+++ b/FakeXrmEasy.2015/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
+++ b/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/FakeXrmEasy.2016/packages.config
+++ b/FakeXrmEasy.2016/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.365/FakeXrmEasy.365.csproj
+++ b/FakeXrmEasy.365/FakeXrmEasy.365.csproj
@@ -40,8 +40,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/FakeXrmEasy.365/packages.config
+++ b/FakeXrmEasy.365/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
+++ b/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">

--- a/FakeXrmEasy.Tests.2013/packages.config
+++ b/FakeXrmEasy.Tests.2013/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
   <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.Workflow" version="6.1.1" targetFramework="net4" />

--- a/FakeXrmEasy.Tests.2015/FakeXrmEasy.Tests.2015.csproj
+++ b/FakeXrmEasy.Tests.2015/FakeXrmEasy.Tests.2015.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/FakeXrmEasy.Tests.2015/packages.config
+++ b/FakeXrmEasy.Tests.2015/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
+++ b/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/FakeXrmEasy.Tests.2016/packages.config
+++ b/FakeXrmEasy.Tests.2016/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.1.0.2" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
+++ b/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
@@ -38,8 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/FakeXrmEasy.Tests.365/packages.config
+++ b/FakeXrmEasy.Tests.365/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net452" />

--- a/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
+++ b/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
@@ -39,8 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="microsoft.crm.sdk.proxy">
@@ -85,7 +85,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FakeXrmEasy\FakeXrmEasy.csproj">

--- a/FakeXrmEasy.Tests/packages.config
+++ b/FakeXrmEasy.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
   <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />

--- a/FakeXrmEasy/FakeXrmEasy.csproj
+++ b/FakeXrmEasy/FakeXrmEasy.csproj
@@ -36,8 +36,8 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="microsoft.crm.sdk.proxy">
@@ -70,7 +70,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="fakexrmeasy.snk" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="..\FakeXrmEasy.Shared\FakeXrmEasy.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/FakeXrmEasy/packages.config
+++ b/FakeXrmEasy/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
   <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />


### PR DESCRIPTION
I needed to update to 3.2 for other reasons - there are no problems with FakeXrmEasy, all tests passing. Makes sense to be on the latest release...