### PR TITLE
fix: FetchXml request with aggregation should still return an alias

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Aggregations.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Aggregations.cs
@@ -176,6 +176,12 @@ namespace FakeXrmEasy
                 {
                     ent[agg.OutputAlias] = new AliasedValue(null, agg.Attribute, val);
                 }
+                else
+                {
+                    //if the aggregate value cannot be calculated
+                    //CRM still returns an alias
+                    ent[agg.OutputAlias] = new AliasedValue(null, agg.Attribute, null);
+                }
             }
 
             return ent;

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/AggregateTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/AggregateTests.cs
@@ -14,8 +14,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
         [Fact]
         public void FetchXml_Aggregate_Group_Count()
         {
-
-
             var fetchXml = @"<fetch version='1.0' output-format='xml-platform' mapping='logical' distinct='false' aggregate='true'>
                               <entity name='contact'>
                                     <attribute name='contactid' alias='count.contacts' aggregate='count' />
@@ -104,6 +102,23 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
             Assert.Equal(3, ent.GetAttributeValue<AliasedValue>("sum")?.Value);
         }
 
+        [Fact]
+        public void FetchXml_Aggregate_Sum_Int_Should_Return_Empty_Alias()
+        {
+            var fetchXml = @"<fetch version='1.0' output-format='xml-platform' mapping='logical' aggregate='true'>
+                              <entity name='contact'>
+                                    <attribute name='numberofchildren' alias='sum' aggregate='sum'/>                                    
+                                  </entity>
+                            </fetch>";
+            var ctx = new XrmFakedContext();
+
+            var collection = ctx.GetFakedOrganizationService().RetrieveMultiple(new FetchExpression(fetchXml));
+
+            Assert.Equal(1, collection.Entities.Count);
+            var ent = collection.Entities[0];
+
+            Assert.True(ent.Contains("sum"));
+        }
 
         [Fact]
         public void FetchXml_Aggregate_Sum_Money()

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/AggregateTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/AggregateTests.cs
@@ -103,24 +103,6 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
         }
 
         [Fact]
-        public void FetchXml_Aggregate_Sum_Int_Should_Return_Empty_Alias()
-        {
-            var fetchXml = @"<fetch version='1.0' output-format='xml-platform' mapping='logical' aggregate='true'>
-                              <entity name='contact'>
-                                    <attribute name='numberofchildren' alias='sum' aggregate='sum'/>                                    
-                                  </entity>
-                            </fetch>";
-            var ctx = new XrmFakedContext();
-
-            var collection = ctx.GetFakedOrganizationService().RetrieveMultiple(new FetchExpression(fetchXml));
-
-            Assert.Equal(1, collection.Entities.Count);
-            var ent = collection.Entities[0];
-
-            Assert.True(ent.Contains("sum"));
-        }
-
-        [Fact]
         public void FetchXml_Aggregate_Sum_Money()
         {
             var fetchXml = @"<fetch version='1.0' output-format='xml-platform' mapping='logical' aggregate='true'>
@@ -339,7 +321,8 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
             var collection = ctx.GetFakedOrganizationService().RetrieveMultiple(new FetchExpression(fetchXml));
             
             Assert.Equal(1, collection.Entities.Count);
-            Assert.Equal(0, collection.Entities.First().Attributes.Count);
+            Assert.Equal(1, collection.Entities.First().Attributes.Count);
+            Assert.True(collection.Entities.First().Contains("sum"));
         }
 
         [Fact]
@@ -358,7 +341,8 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
             var collection = ctx.GetFakedOrganizationService().RetrieveMultiple(new FetchExpression(fetchXml));
 
             Assert.Equal(1, collection.Entities.Count);
-            Assert.Equal(0, collection.Entities.First().Attributes.Count);
+            Assert.Equal(1, collection.Entities.First().Attributes.Count);
+            Assert.True(collection.Entities.First().Contains("avg"));
         }
 
         [Fact]


### PR DESCRIPTION
CRM still returns an aliased field even if it's empty for FetchXML request (without grouping).

For example:
```xml
<fetch version="1.0" output-format="xml-platform" mapping="logical" aggregate="true" >
    <entity name="invoicedetail" >
        <attribute name="extendedamount" alias="extendedamount_sum" aggregate="sum" />
        <filter type="and" >
            <condition attribute="productid" operator="eq" value="00000000-0000-0000-0000-000000000002" />
            <condition attribute="invoiceid" operator="eq" value="cb8d1a91-9160-4702-a4bd-e5eff56f0bd7" />
        </filter>
    </entity>
</fetch>
```
Returns:
```xml
<resultset morerecords="0" >
    <result>
        <extendedamount_sum/>
    </result>
</resultset>
```