### PR TITLE
The trace output should also be sent to the default output

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedTracingService.cs
+++ b/FakeXrmEasy.Shared/XrmFakedTracingService.cs
@@ -18,6 +18,8 @@ namespace FakeXrmEasy
 
         public void Trace(string format, params object[] args)
         {
+            Console.WriteLine(format, args);
+
             _trace += string.Format(format, args) + System.Environment.NewLine;
         }
 


### PR DESCRIPTION
In context of #121 we should simply write the trace messages to the default output. This is then usually also collected by the unit test runners.

I am aware of the `DumpTrace` method, however I want to avoid adding boilerplate code to the unit tests, to see the trace messages which were produced.

Maybe it would make sense to prepend "Plugin: " before the trace output to have a visible differentiator for output coming from the plugin vs. output of the test itself