### PR TITLE
Added support for like operator with % sign at both ends. e.g. %Dummy%

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/XmlExtensionsForFetchXml.cs
+++ b/FakeXrmEasy.Shared/Extensions/XmlExtensionsForFetchXml.cs
@@ -355,6 +355,8 @@ namespace FakeXrmEasy.Extensions.FetchXml
                             op = ConditionOperator.EndsWith;
                         else if (!value.StartsWith("%") && value.EndsWith("%"))
                             op = ConditionOperator.BeginsWith;
+                        else if (value.StartsWith("%") && value.EndsWith("%"))
+                            op = ConditionOperator.Contains;
 
                         value = value.Replace("%", "");
                     }
@@ -369,6 +371,8 @@ namespace FakeXrmEasy.Extensions.FetchXml
                             op = ConditionOperator.DoesNotEndWith;
                         else if (!value.StartsWith("%") && value.EndsWith("%"))
                             op = ConditionOperator.DoesNotBeginWith;
+                        else if (value.StartsWith("%") && value.EndsWith("%"))
+                            op = ConditionOperator.DoesNotContain;
 
                         value = value.Replace("%", "");
                     }


### PR DESCRIPTION
Please include this change to handle conditions like below:

<condition attribute='fullname' value='%Dummy%' operator='like'/>