### PR TITLE
Fixed an issue with more null handling

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -247,7 +247,10 @@ namespace FakeXrmEasy.Extensions
 
             foreach (var attKey in e.Attributes.Keys)
             {
-                cloned[attKey] = e[attKey] != null ? CloneAttribute(e[attKey]) : null;
+                if (e[attKey] != null)
+                {
+                    cloned[attKey] = CloneAttribute(e[attKey]);
+                }
             }
             return cloned;
         }


### PR DESCRIPTION
This fixes another problem with null handling and makes the handling more in line with the way dynamics handles it. The particular case that I ran into this was in a linked entity.

Current Functionality: Null fields are returned in the entity
CRM Functionality: Null fields are not returned in the entity