### PR TITLE
Add support for ServiceProvider.GetService(typeof(IExecutionContext))

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -70,6 +70,42 @@ namespace FakeXrmEasy
             return context;
         }
 
+        protected IExecutionContext GetFakedExecutionContext(XrmFakedPluginExecutionContext ctx)
+        {
+            var context = A.Fake<IExecutionContext>();
+            
+            var newUserId = Guid.NewGuid();
+
+            A.CallTo(() => context.Depth).ReturnsLazily(() => ctx.Depth <= 0 ? 1 : ctx.Depth);
+            A.CallTo(() => context.IsExecutingOffline).ReturnsLazily(() => ctx.IsExecutingOffline);
+            A.CallTo(() => context.InputParameters).ReturnsLazily(() => ctx.InputParameters);
+            A.CallTo(() => context.OutputParameters).ReturnsLazily(() => ctx.OutputParameters);
+            A.CallTo(() => context.PreEntityImages).ReturnsLazily(() => ctx.PreEntityImages);
+            A.CallTo(() => context.PostEntityImages).ReturnsLazily(() => ctx.PostEntityImages);
+            A.CallTo(() => context.MessageName).ReturnsLazily(() => ctx.MessageName);
+            A.CallTo(() => context.Mode).ReturnsLazily(() => ctx.Mode);
+            A.CallTo(() => context.OrganizationName).ReturnsLazily(() => ctx.OrganizationName);
+            A.CallTo(() => context.OrganizationId).ReturnsLazily(() => ctx.OrganizationId);
+            A.CallTo(() => context.InitiatingUserId).ReturnsLazily(() => ctx.InitiatingUserId == Guid.Empty ? newUserId : ctx.InitiatingUserId);
+            A.CallTo(() => context.UserId).ReturnsLazily(() => ctx.UserId == Guid.Empty ? newUserId : ctx.UserId);
+            A.CallTo(() => context.PrimaryEntityName).ReturnsLazily(() => ctx.PrimaryEntityName);
+            A.CallTo(() => context.SecondaryEntityName).ReturnsLazily(() => ctx.SecondaryEntityName);
+            A.CallTo(() => context.SharedVariables).ReturnsLazily(() => ctx.SharedVariables);
+
+            //Create message will pass an Entity as the target but this is not always true
+            //For instance, a Delete request will receive an EntityReference
+            if (ctx.InputParameters != null &&
+                ctx.InputParameters.ContainsKey("Target") &&
+                ctx.InputParameters["Target"] is Entity)
+            {
+                var target = ctx.InputParameters["Target"] as Entity;
+                A.CallTo(() => context.PrimaryEntityId).ReturnsLazily(() => target.Id);
+                A.CallTo(() => context.PrimaryEntityName).ReturnsLazily(() => target.LogicalName);
+            }
+
+            return context;
+        }
+
         public IPlugin ExecutePluginWith<T>(XrmFakedPluginExecutionContext ctx, T instance) where T : IPlugin, new()
         {
             var fakedServiceProvider = GetFakedServiceProvider(ctx);
@@ -216,6 +252,10 @@ namespace FakeXrmEasy
                    else if (t.Equals(typeof(IPluginExecutionContext)))
                    {
                        return GetFakedPluginContext(plugCtx);
+                   }
+                   else if (t.Equals(typeof(IExecutionContext)))
+                   {
+                       return GetFakedExecutionContext(plugCtx);
                    }
                    else if (t.Equals(typeof(IOrganizationServiceFactory)))
                    {


### PR DESCRIPTION
I couldn't find a smart way to make GetFakedPluginContext call GetFakedExecutionContext and just add the two additional methods (ParentContext and Stage) so it's now a simple copy&paste of the existing code sans the 2 mentioned methods.