### PR TITLE
Set default owner on entity create

### DIFF
--- a/FakeXrmEasy.Shared/Services/EntityInitializer/DefaultEntityInitializerService.cs
+++ b/FakeXrmEasy.Shared/Services/EntityInitializer/DefaultEntityInitializerService.cs
@@ -25,6 +25,7 @@ namespace FakeXrmEasy.Services
             e.SetValueIfEmpty("modifiedon", now);
             e.SetValueIfEmpty("createdby", CallerId);
             e.SetValueIfEmpty("modifiedby", CallerId);
+            e.SetValueIfEmpty("ownerid", CallerId);
             e.SetValueIfEmpty("statecode", new OptionSetValue(0)); //Active by default
 
             return e;

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestRetrieve.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestRetrieve.cs
@@ -117,7 +117,7 @@ namespace FakeXrmEasy.Tests
 
             var result = service.Retrieve("account", guid, new ColumnSet(true));
             Assert.Equal(result.Id, data.FirstOrDefault().Id);
-            Assert.Equal(result.Attributes.Count, 6);
+            Assert.Equal(result.Attributes.Count, 7);
         }
 
         [Fact]

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/LinqTests/FakeContextTestLinqQueries.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/LinqTests/FakeContextTestLinqQueries.cs
@@ -755,7 +755,7 @@ namespace FakeXrmEasy.Tests
                                }).ToList();
 
                 Assert.True(matches.Count == 1);
-                Assert.Equal(matches[0].Contact.Attributes.Count, 6 + 1);
+                Assert.Equal(matches[0].Contact.Attributes.Count, 7 + 1);
             }
         }
 
@@ -796,7 +796,7 @@ namespace FakeXrmEasy.Tests
                                }).ToList();
 
                 Assert.True(matches.Count == 1);
-                Assert.Equal(matches[0].Contact.Attributes.Count, 6 + 1);
+                Assert.Equal(matches[0].Contact.Attributes.Count, 7 + 1);
             }
         }
 
@@ -840,7 +840,7 @@ namespace FakeXrmEasy.Tests
                                }).ToList();
 
                 Assert.True(matches.Count == 1);
-                Assert.Equal(matches[0].Account.Attributes.Count, 6 + 4); //6 = default attributes
+                Assert.Equal(matches[0].Account.Attributes.Count, 7 + 4); //7 = default attributes
             }
         }
 
@@ -886,7 +886,7 @@ namespace FakeXrmEasy.Tests
                                }).ToList();
 
                 Assert.True(matches.Count == 1);
-                Assert.Equal(matches[0].Account.Attributes.Count, 6 + 4); //6 = default attributes
+                Assert.Equal(matches[0].Account.Attributes.Count, 7 + 4); //7 = default attributes
             }
         }
 
@@ -931,7 +931,7 @@ namespace FakeXrmEasy.Tests
                                }).ToList();
 
                 Assert.True(matches.Count == 1);
-                Assert.Equal(matches[0].Account.Attributes.Count, 6 + 4); //6 = default attributes
+                Assert.Equal(matches[0].Account.Attributes.Count, 7 + 4); //6 = default attributes
             }
         }
 

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
@@ -337,11 +337,11 @@ namespace FakeXrmEasy.Tests
             var firstContact = result.FirstOrDefault();
             var lastContact = result.LastOrDefault();
 
-            //Contact 1 attributes = 4 + 5 (the extra five are the CreatedOn, ModifiedOn, CreatedBy, ModifiedBy + StateCode attributes generated automatically
-            //+ Attributes from the join(account) = 2 + 5
+            //Contact 1 attributes = 4 + 6 (the extra five are the CreatedOn, ModifiedOn, CreatedBy, ModifiedBy, OwnerId + StateCode attributes generated automatically
+            //+ Attributes from the join(account) = 2 + 6
 
-            Assert.True(firstContact.Attributes.Count == 16);
-            Assert.True(lastContact.Attributes.Count == 16);  
+            Assert.True(firstContact.Attributes.Count == 18);
+            Assert.True(lastContact.Attributes.Count == 18);  
         }
 
         [Fact]

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
@@ -337,7 +337,7 @@ namespace FakeXrmEasy.Tests
             var firstContact = result.FirstOrDefault();
             var lastContact = result.LastOrDefault();
 
-            //Contact 1 attributes = 4 + 6 (the extra five are the CreatedOn, ModifiedOn, CreatedBy, ModifiedBy, OwnerId + StateCode attributes generated automatically
+            //Contact 1 attributes = 4 + 6 (the extra six are the CreatedOn, ModifiedOn, CreatedBy, ModifiedBy, OwnerId + StateCode attributes generated automatically
             //+ Attributes from the join(account) = 2 + 6
 
             Assert.True(firstContact.Attributes.Count == 18);

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -92,6 +92,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\TestPropertiesPlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\TestSharedVariablesPropertyPlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\TestContextPlugin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestDefaultEntityInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tracing\XrmFakeTracingExample.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XrmRealContextTests\XrmRealContextTests.cs" />
   </ItemGroup>

--- a/FakeXrmEasy.Tests.Shared/TestDefaultEntityInitializer.cs
+++ b/FakeXrmEasy.Tests.Shared/TestDefaultEntityInitializer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace FakeXrmEasy.Tests
+{
+    public class TestDefaultEntityInitializer
+    {
+        [Fact]
+        public void TestWithUnpopulatedValues()
+        {
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+
+            List<Entity> initialEntities = new List<Entity>();
+
+            Entity user = new Entity("systemuser");
+            user.Id = Guid.NewGuid();
+            initialEntities.Add(user);
+
+            context.CallerId = user.ToEntityReference();
+
+            Entity testEntity = new Entity("test");
+            testEntity.Id = Guid.NewGuid();
+            initialEntities.Add(testEntity);
+
+            context.Initialize(initialEntities);
+            Entity testPostCreate = service.Retrieve("test", testEntity.Id, new ColumnSet(true));
+            Assert.Equal(user.ToEntityReference(), testPostCreate["ownerid"]);
+            Assert.Equal(user.ToEntityReference(), testPostCreate["createdby"]);
+            Assert.Equal(user.ToEntityReference(), testPostCreate["modifiedby"]);
+        }
+    }
+}


### PR DESCRIPTION
Sets the default owner of created entities to the current user if none is specified (which is the default for CRM)