### PR TITLE
Fixes Orders in QueryExpression not working if column isn't in column set

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -324,9 +324,6 @@ namespace FakeXrmEasy
             Expression<Func<Entity, bool>> lambda = Expression.Lambda<Func<Entity, bool>>(expTreeBody, entity);
             query = query.Where(lambda);
 
-            //Project the attributes in the root column set  (must be applied after the where clause, not before!!)
-            query = query.Select(x => x.Clone(x.GetType()).ProjectAttributes(qe, context));
-
             //Sort results
             if (qe.Orders != null)
             {
@@ -353,6 +350,9 @@ namespace FakeXrmEasy
                     query = orderedQuery;
                 }
             }
+
+            //Project the attributes in the root column set  (must be applied after the where and order clauses, not before!!)
+            query = query.Select(x => x.Clone(x.GetType()).ProjectAttributes(qe, context));
 
             //Apply TopCount
 

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/OrderByTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/OrderByTests.cs
@@ -591,5 +591,35 @@ namespace FakeXrmEasy.Tests.FakeContextTests.TranslateQueryExpressionTests
             Assert.True(names[4].Equals("11"));
             Assert.True(names[5].Equals("12"));
         }
+
+        [Fact]
+        public void When_ordering_column_is_not_in_column_set_ordering_is_still_correct()
+        {
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+            List<Entity> initialEntities = new List<Entity>();
+
+            Entity secondEntity = new Entity("entity");
+            secondEntity.Id = Guid.NewGuid();
+            secondEntity["int"] = 2;
+            secondEntity["text"] = "second";
+            initialEntities.Add(secondEntity);
+
+            Entity firstEntity = new Entity("entity");
+            firstEntity.Id = Guid.NewGuid();
+            firstEntity["int"] = 1;
+            firstEntity["text"] = "first";
+            initialEntities.Add(firstEntity);
+
+            context.Initialize(initialEntities);
+
+            QueryExpression query = new QueryExpression("entity");
+            query.ColumnSet = new ColumnSet("text");
+            query.AddOrder("int", OrderType.Ascending);
+
+            EntityCollection result = service.RetrieveMultiple(query);
+            Assert.Equal(firstEntity.Id, result.Entities[0].Id);
+            Assert.Equal(secondEntity.Id, result.Entities[1].Id);
+        }
     }
 }


### PR DESCRIPTION
Fixes Orders in Query Expressions not working if the ordering field is not in the column set.

Current functionality:

Orders in Query Expressions don't actually order if the column isn't in the column set.

Patched functionality:

Orders in Query Expressions still sort even if the column is not in the column set.