### PR TITLE
TracingService could now be retrieved without executing a plugin before

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.CodeActivities.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.CodeActivities.cs
@@ -74,8 +74,7 @@ namespace FakeXrmEasy
                 sDebug += "Adding extensions..." + System.Environment.NewLine;
                 invoker.Extensions.Add<ITracingService>(() =>
                 {
-                    _tracingService = new XrmFakedTracingService();
-                    return _tracingService;
+                    return TracingService;
                 });
                 invoker.Extensions.Add<IWorkflowContext>(() =>
                 {

--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -225,8 +225,7 @@ namespace FakeXrmEasy
                    }
                    else if (t.Equals(typeof(ITracingService)))
                    {
-                       _tracingService = new XrmFakedTracingService();
-                       return _tracingService;
+                       return TracingService;
                    }
                    else if (t.Equals(typeof(IPluginExecutionContext)))
                    {
@@ -259,7 +258,7 @@ namespace FakeXrmEasy
 
         public XrmFakedTracingService GetFakeTracingService()
         {
-            return _tracingService;
+            return TracingService;
         }
 
     }

--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -24,6 +24,10 @@ namespace FakeXrmEasy
 
         protected internal IOrganizationService Service { get; set; }
 
+        private readonly Lazy<XrmFakedTracingService> _tracingService = new Lazy<XrmFakedTracingService>(() => new XrmFakedTracingService());
+
+        protected internal XrmFakedTracingService TracingService => _tracingService.Value;
+
         protected internal bool Initialised { get; set; }
 
         public Dictionary<string, Dictionary<Guid, Entity>> Data { get; set; }
@@ -50,8 +54,6 @@ namespace FakeXrmEasy
         private Dictionary<string, XrmFakedRelationship> Relationships { get; set; }
 
         public Dictionary<string, OptionSetMetadata> OptionSetValuesMetadata { get; set; }
-
-        protected internal XrmFakedTracingService _tracingService { get; set; }
 
         public IEntityInitializerService EntityInitializerService { get; set; }
         public IAccessRightsRepository AccessRightsRepository { get; set; }

--- a/FakeXrmEasy.Tests.Shared/Tracing/XrmFakeTracingExample.cs
+++ b/FakeXrmEasy.Tests.Shared/Tracing/XrmFakeTracingExample.cs
@@ -17,7 +17,7 @@ namespace FakeXrmEasy.Tests.Tracing
 
             var guid1 = Guid.NewGuid();
             var target = new Entity("account") { Id = guid1 };
-
+            
             //Execute our plugin against a target that doesn't contains the accountnumber attribute
             var fakedPlugin = fakedContext.ExecutePluginWithTarget<AccountNumberPlugin>(target);
 
@@ -48,6 +48,34 @@ namespace FakeXrmEasy.Tests.Tracing
 
             //Assert that the target contains a new attribute      
             Assert.Equal(log, "Some trace written" + System.Environment.NewLine);
+        }
+
+        [Fact]
+        public void The_TracingService_Should_Be_Retrievable_Without_Calling_Execute_Before()
+        {
+            var fakedContext = new XrmFakedContext();
+
+            //Get tracing service
+            var fakeTracingService = fakedContext.GetFakeTracingService();  
+            
+            Assert.NotNull(fakeTracingService);         
+        }
+
+        [Fact]
+        public void Retrieving_The_TracingService_Twice_Should_Return_The_Same_Instance()
+        {
+            var fakedContext = new XrmFakedContext();
+
+            //Get tracing service
+            var fakeTracingService1 = fakedContext.GetFakeTracingService();
+            fakeTracingService1.Trace("foobar");
+
+            var fakeTracingService2 = fakedContext.GetFakeTracingService();
+
+            Assert.NotNull(fakeTracingService1);
+            Assert.NotNull(fakeTracingService2);
+
+            Assert.Contains("foobar", fakeTracingService2.DumpTrace());
         }
     }
 }


### PR DESCRIPTION
It was not possible to retrieve a TracingService without calling Execute before. I've changed the implementation, so that this is now possible.