### PR TITLE
Make multiple unaliased joins work more like CRM

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Pipeline.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Pipeline.cs
@@ -178,10 +178,12 @@ namespace FakeXrmEasy
                 {
                     new LinkEntity("sdkmessageprocessingstep", "sdkmessagefilter", "sdkmessagefilterid", "sdkmessagefilterid", JoinOperator.LeftOuter)
                     {
+                        EntityAlias = "sdkmessagefilter",
                         Columns = new ColumnSet("primaryobjecttypecode")
                     },
                     new LinkEntity("sdkmessageprocessingstep", "sdkmessage", "sdkmessageid", "sdkmessageid", JoinOperator.Inner)
                     {
+                        EntityAlias = "sdkmessage",
                         Columns = new ColumnSet("name"),
                         LinkCriteria =
                         {
@@ -193,6 +195,7 @@ namespace FakeXrmEasy
                     },
                     new LinkEntity("sdkmessageprocessingstep", "plugintype", "eventhandler", "plugintypeid", JoinOperator.Inner)
                     {
+                        EntityAlias = "plugintype",
                         Columns = new ColumnSet("assemblyname", "typename")
                     }
                 }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
@@ -565,9 +565,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
         }
 
         [Fact]
-        public void
-            When_querying_by_an_attribute_which_wasnt_initialised_null_value_is_returned_for_early_bound_and_not_an_exception
-            ()
+        public void When_querying_by_an_attribute_which_wasnt_initialised_null_value_is_returned_for_early_bound_and_not_an_exception()
         {
             var ctx = new XrmFakedContext();
             ctx.ProxyTypesAssembly = Assembly.GetAssembly(typeof(Contact));
@@ -829,5 +827,236 @@ namespace FakeXrmEasy.Tests.FakeContextTests
             Assert.Equal(1, incidents.Count);
         }
 #endif
+
+        [Fact]
+        public void When_There_Is_A_LinkedEntity_The_Output_EntityAlias_Should_Be_Suffixed_With_1()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var entities = new List<Entity>();
+
+            var user1 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User1"
+            };
+            entities.Add(user1);
+
+            var user2 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User2",
+                ["modifiedby"] = user1.ToEntityReference()
+            };
+            entities.Add(user2);
+
+            context.Initialize(entities);
+
+            var query = new QueryExpression(SystemUser.EntityLogicalName)
+            {
+                LinkEntities =
+                {
+                    new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                    {
+                        Columns = new ColumnSet("fullname"),
+                    }
+                }
+            };
+
+            var result = service.RetrieveMultiple(query);
+            var resultingEntity = result.Entities[0];
+            Assert.Equal(2, resultingEntity.Attributes.Count);
+            Assert.Equal("User1", ((AliasedValue)resultingEntity["systemuser1.fullname"]).Value);
+        }
+
+        [Fact]
+        public void When_There_Are_Multiple_LinkedEntities_The_Output_EntityAlias_Should_All_Be_Suffixed_With_1()
+
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var entities = new List<Entity>();
+
+            var user1 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User1"
+            };
+            entities.Add(user1);
+
+            var businessUnit = new BusinessUnit
+            {
+                Id = Guid.NewGuid(),
+                Name = "BusinessUnit1"
+            };
+            entities.Add(businessUnit);
+
+            var user2 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                BusinessUnitId = businessUnit.ToEntityReference(),
+                ["fullname"] = "User2",
+                ["modifiedby"] = user1.ToEntityReference()
+            };
+            entities.Add(user2);
+
+            context.Initialize(entities);
+
+            var query = new QueryExpression(SystemUser.EntityLogicalName)
+            {
+                LinkEntities =
+                {
+                    new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                    {
+                        Columns = new ColumnSet("fullname"),
+                    },
+                    new LinkEntity(SystemUser.EntityLogicalName, BusinessUnit.EntityLogicalName, "businessunitid", "businessunitid", JoinOperator.Inner)
+                    {
+                        Columns = new ColumnSet("name"),
+                    }
+                }
+            };
+
+            var result = service.RetrieveMultiple(query);
+            var resultingEntity = result.Entities[0];
+            Assert.Equal(3, resultingEntity.Attributes.Count);
+            Assert.Equal("User1", ((AliasedValue)resultingEntity["systemuser1.fullname"]).Value);
+            Assert.Equal("BusinessUnit1", ((AliasedValue)resultingEntity["businessunit1.name"]).Value);
+        }
+
+        [Fact]
+        public void When_There_Are_Multiple_LinkedEntities_With_The_Same_Entitiy_The_Output_EntityAlias_Should_All_Be_Suffixed_With_Incrementally()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var entities = new List<Entity>();
+
+            var user1 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User1"
+            };
+            entities.Add(user1);
+
+            var user2 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User2",
+                ["modifiedby"] = user1.ToEntityReference()
+            };
+            entities.Add(user2);
+
+            var user3 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User3",
+                ["modifiedby"] = user2.ToEntityReference()
+            };
+            entities.Add(user3);
+
+            context.Initialize(entities);
+
+            var query = new QueryExpression(SystemUser.EntityLogicalName)
+            {
+                LinkEntities =
+                {
+                    new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                    {
+                        Columns = new ColumnSet("fullname"),
+                        LinkEntities =
+                        {
+                            new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                            {
+                                Columns = new ColumnSet("fullname"),
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = service.RetrieveMultiple(query);
+            var resultingEntity = result.Entities[0];
+            Assert.Equal(3, resultingEntity.Attributes.Count);
+            Assert.Equal("User2", ((AliasedValue)resultingEntity["systemuser1.fullname"]).Value);
+            Assert.Equal("User1", ((AliasedValue)resultingEntity["systemuser2.fullname"]).Value);
+        }
+
+        [Fact]
+        public void When_There_Are_Multiple_LinkedEntities_With_The_Same_Entitiy_And_One_Has_An_Alias_The_Output_EntityAlias_Should_All_Be_Suffixed_With_Incrementally_Ignoring_The_Aliased_One()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var entities = new List<Entity>();
+
+            var user1 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User1"
+            };
+            entities.Add(user1);
+
+            var user2 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User2",
+                ["modifiedby"] = user1.ToEntityReference()
+            };
+            entities.Add(user2);
+
+            var user3 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User3",
+                ["modifiedby"] = user2.ToEntityReference()
+            };
+            entities.Add(user3);
+
+            var user4 = new SystemUser
+            {
+                Id = Guid.NewGuid(),
+                ["fullname"] = "User4",
+                ["modifiedby"] = user3.ToEntityReference()
+            };
+            entities.Add(user4);
+
+            context.Initialize(entities);
+
+            var query = new QueryExpression(SystemUser.EntityLogicalName)
+            {
+                LinkEntities =
+                {
+                    new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                    {
+                        Columns = new ColumnSet("fullname"),
+                        LinkEntities =
+                        {
+                            new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                            {
+                                EntityAlias = "systemuserwithalias",
+                                Columns = new ColumnSet("fullname"),
+                                LinkEntities =
+                                {
+                                    new LinkEntity(SystemUser.EntityLogicalName, SystemUser.EntityLogicalName, "modifiedby", "systemuserid", JoinOperator.Inner)
+                                    {
+                                        Columns = new ColumnSet("fullname")
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            var result = service.RetrieveMultiple(query);
+            var resultingEntity = result.Entities[0];
+            Assert.Equal(4, resultingEntity.Attributes.Count);
+            Assert.Equal("User3", ((AliasedValue)resultingEntity["systemuser1.fullname"]).Value);
+            Assert.Equal("User2", ((AliasedValue)resultingEntity["systemuserwithalias.fullname"]).Value);
+            Assert.Equal("User1", ((AliasedValue)resultingEntity["systemuser2.fullname"]).Value);
+        }
     }
 }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/TranslateQueryExpressionTests/FakeContextTestTranslateQueryExpression.cs
@@ -80,10 +80,10 @@ namespace FakeXrmEasy.Tests
             Assert.True(secondContact.Attributes.Count == 3);
 
             Assert.True(firstContact["fullname"].Equals(contact1["fullname"]));
-            Assert.True((firstContact["account.name"] as AliasedValue).Value.Equals(account["name"]));
+            Assert.True((firstContact["account1.name"] as AliasedValue).Value.Equals(account["name"]));
 
             Assert.True(secondContact["fullname"].Equals(contact2["fullname"]));
-            Assert.True((secondContact["account.name"] as AliasedValue).Value.Equals(account["name"]));
+            Assert.True((secondContact["account1.name"] as AliasedValue).Value.Equals(account["name"]));
         }
 
         [Fact]
@@ -417,11 +417,11 @@ namespace FakeXrmEasy.Tests
             Assert.True(firstContact.Attributes.Count == 1); //Contact 1
             Assert.True(lastContact.Attributes.Count == 1);  //Contact 2
 
-            Assert.True(firstContact.Attributes.ContainsKey("account.name")); //Contact 1
-            Assert.True(lastContact.Attributes.ContainsKey("account.name"));  //Contact 2
+            Assert.True(firstContact.Attributes.ContainsKey("account1.name")); //Contact 1
+            Assert.True(lastContact.Attributes.ContainsKey("account1.name"));  //Contact 2
 
-            Assert.True(firstContact.Attributes["account.name"] is AliasedValue); //Contact 1
-            Assert.True(lastContact.Attributes["account.name"] is AliasedValue);  //Contact 2
+            Assert.True(firstContact.Attributes["account1.name"] is AliasedValue); //Contact 1
+            Assert.True(lastContact.Attributes["account1.name"] is AliasedValue);  //Contact 2
         }
 
         [Fact]

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -76,6 +76,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\XrmFakedRelationshipTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GeneratedCode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue116.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issues\Issue165.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issues\Issue180.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issues\Issue125.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issues\Issue156.cs" />

--- a/FakeXrmEasy.Tests.Shared/Issues/Issue165.cs
+++ b/FakeXrmEasy.Tests.Shared/Issues/Issue165.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Crm;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.Issues
+{
+    public class Issue165
+    {
+        [Fact]
+        public void TestMultipleUnaliasedJoins()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var account = new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["firstname"] = "Test"
+            };
+
+            var secondAccount = new Entity("account")
+            {
+                Id = Guid.NewGuid(),
+                ["firstname"] = "secondTest"
+            };
+
+            var contact = new Entity("contact")
+            {
+                Id = Guid.NewGuid(),
+                ["parent"] = account.ToEntityReference(),
+                ["otherparent"] = secondAccount.ToEntityReference()
+            };
+
+            context.Initialize(new List<Entity>() { account, secondAccount, contact });
+
+            QueryExpression query = new QueryExpression("contact");
+
+            var firstLink = new LinkEntity("contact", "account", "parent", "accountid", JoinOperator.LeftOuter)
+            {
+                Columns = new ColumnSet("firstname")
+            };
+            query.LinkEntities.Add(firstLink);
+
+            var secondLink = new LinkEntity("contact", "account", "otherparent", "accountid", JoinOperator.LeftOuter)
+            {
+                Columns = new ColumnSet("firstname")
+            };
+            query.LinkEntities.Add(secondLink);
+
+            var result = service.RetrieveMultiple(query);
+            Entity resultingEntity = result.Entities[0];
+            Assert.Equal(2, resultingEntity.Attributes.Count);
+            Assert.Equal("Test", ((AliasedValue)resultingEntity["account1.firstname"]).Value);
+            Assert.Equal("secondTest", ((AliasedValue)resultingEntity["account2.firstname"]).Value);
+        }
+    }
+}

--- a/FakeXrmEasy.Tests.Shared/Issues/Issue191.cs
+++ b/FakeXrmEasy.Tests.Shared/Issues/Issue191.cs
@@ -67,8 +67,8 @@ namespace FakeXrmEasy.Tests.Issues
             Console.WriteLine(count2); // returns 1 record
 
             var results = service.RetrieveMultiple(query2);
-            Assert.Equal(true, results.Entities[0].Attributes.ContainsKey("child.contactid"));
-            Assert.Equal(true, results.Entities[0].Attributes.ContainsKey("pet.childid")); //test fails unless link22 is Inner join
+            Assert.Equal(true, results.Entities[0].Attributes.ContainsKey("child1.contactid"));
+            Assert.Equal(true, results.Entities[0].Attributes.ContainsKey("pet1.childid")); //test fails unless link22 is Inner join
         }
     }
 }

--- a/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
+++ b/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.Data.Services.Client" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>


### PR DESCRIPTION
Added more CRM behaviour
- Only valid EntityAlias allowed at a LinkEntity in a QueryExression
- Naming of linked attributes is now incremental instead of overwritting other attributes

Should fix #165 