### PR TITLE
Adding SetSealedPropertyValue extension for EntityMetadata

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityMetadataExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityMetadataExtensions.cs
@@ -20,6 +20,11 @@ namespace FakeXrmEasy.Extensions
             entityMetadata.GetType().GetProperty("Attributes").SetValue(entityMetadata, attributes.ToList().ToArray(), null);
         }
 
+        public static void SetSealedPropertyValue(this EntityMetadata entityMetadata, string sPropertyName, object value)
+        {
+            entityMetadata.GetType().GetProperty(sPropertyName).SetValue(entityMetadata, value, null);
+        }
+
         public static void SetSealedPropertyValue(this AttributeMetadata attributeMetadata, string sPropertyName, object value)
         {
             attributeMetadata.GetType().GetProperty(sPropertyName).SetValue(attributeMetadata, value, null);

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveEntityRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveEntityRequestExecutor.cs
@@ -46,7 +46,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
             {
                 if(!ctx.EntityMetadata.ContainsKey(req.LogicalName))
                 {
-                    throw new Exception("The specified entity name wasn't found in the metadata cache");
+                    throw new Exception($"Entity '{req.LogicalName}' is now found in the metadata cache");
                 }
 
                 var entityMetadata = ctx.GetEntityMetadataByName(req.LogicalName);

--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveEntityRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveEntityRequestExecutor.cs
@@ -46,7 +46,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
             {
                 if(!ctx.EntityMetadata.ContainsKey(req.LogicalName))
                 {
-                    throw new Exception($"Entity '{req.LogicalName}' is now found in the metadata cache");
+                    throw new Exception($"Entity '{req.LogicalName}' is not found in the metadata cache");
                 }
 
                 var entityMetadata = ctx.GetEntityMetadataByName(req.LogicalName);


### PR DESCRIPTION
In my case used to be able to set ``PrimaryNameAttribute`` on the ``EntityMetadata``.

Sample:
```
        private static EntityMetadata InitializeEntityMetadata(string logicalname, string primaryattribute = "name")
        {
            var meta = new EntityMetadata()
            {
                LogicalName = logicalname
            };
            meta.SetSealedPropertyValue("PrimaryNameAttribute", primaryattribute);
            return meta;
        }
```