### PR TITLE
Fix Generic Message Executor

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -275,10 +275,15 @@ namespace FakeXrmEasy
                     {
                         return context.ExecutionMocks[req.GetType()].Invoke(req);
                     }
+
                     if (context.FakeMessageExecutors.ContainsKey(req.GetType()))
                     {
-                        return context.FakeMessageExecutors[req.GetType()].Execute(req, context);
+                        if (context.FakeMessageExecutors[req.GetType()].CanExecute(req))
+                        {
+                            return context.FakeMessageExecutors[req.GetType()].Execute(req, context);
+                        }
                     }
+
                     if (req.GetType() == typeof(OrganizationRequest) && context.GenericFakeMessageExecutors.ContainsKey(req.RequestName))
                     {
                         return context.GenericFakeMessageExecutors[req.RequestName].Execute(req, context);

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -73,6 +73,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\RetrieveVersionRequestTests\RetrieveVersionRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\ReviseQuoteRequestTests\ReviseQuoteRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\SetStateRequestTests\SetStateRequestTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TestGenericMessageExecutors.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\ConditionExpressionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\FakeContextTestFormattedValues.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\FakeContextTestTranslateQueryExpression.cs" />


### PR DESCRIPTION
The executor for NavigateToNextEntityOrganizationRequestExecutor was catching every generic OrganizationRequest which was in turn nullifying the generic message executor. This resolves that by checking if the message executor should be handling the message.