### PR TITLE
Use the lowest possible dependency to increase compatibility in the field.

### DIFF
--- a/FakeXrmEasy.2011.nuspec
+++ b/FakeXrmEasy.2011.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2011 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.Xrm.Sdk.2011" version="5.0.18" />
-      <dependency id="Microsoft.Xrm.Sdk.Workflow.2011" version="5.0.18" />
-      <dependency id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" />
-      <dependency id="Microsoft.Xrm.Client.2011" version="5.0.18" />
+      <dependency id="Microsoft.Xrm.Sdk.2011" version="5.0" />
+      <dependency id="Microsoft.Xrm.Sdk.Workflow.2011" version="5.0" />
+      <dependency id="Microsoft.Crm.Sdk.Proxy.2011" version="5.08" />
+      <dependency id="Microsoft.Xrm.Client.2011" version="5.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net40" />

--- a/FakeXrmEasy.2011.nuspec
+++ b/FakeXrmEasy.2011.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2011 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.Xrm.Sdk.2011" version="5.0" />
-      <dependency id="Microsoft.Xrm.Sdk.Workflow.2011" version="5.0" />
-      <dependency id="Microsoft.Crm.Sdk.Proxy.2011" version="5.08" />
-      <dependency id="Microsoft.Xrm.Client.2011" version="5.0" />
+      <dependency id="Microsoft.Xrm.Sdk.2011" version="5.0.18" />
+      <dependency id="Microsoft.Xrm.Sdk.Workflow.2011" version="5.0.18" />
+      <dependency id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" />
+      <dependency id="Microsoft.Xrm.Client.2011" version="5.0.18" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net40" />

--- a/FakeXrmEasy.2013.nuspec
+++ b/FakeXrmEasy.2013.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2013 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="6.1.1" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="6.1.1" />
-      <dependency id="Microsoft.CrmSdk.Extensions" version="6.0.4.1" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="6.0" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="6.0" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="6.0" />
+      <dependency id="Microsoft.CrmSdk.Extensions" version="6.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net40" />

--- a/FakeXrmEasy.2013.nuspec
+++ b/FakeXrmEasy.2013.nuspec
@@ -15,7 +15,7 @@
     <tags>dynamics crm 2013 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="6.0" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="6.1" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="6.0" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="6.0" />
       <dependency id="Microsoft.CrmSdk.Extensions" version="6.0" />

--- a/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
+++ b/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
@@ -37,52 +37,45 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AntiXSSLibrary, Version=4.0.0.0, Culture=neutral, PublicKeyToken=d127efab8a9c114f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\AntiXSSLibrary.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.0\lib\net40\AntiXSSLibrary.dll</HintPath>
     </Reference>
     <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Crm.Sdk.Proxy">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.0\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ServiceBus, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WindowsAzure.ServiceBus.2.1.2.0\lib\net40-full\Microsoft.ServiceBus.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.2.0.0.0\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Xrm.Client, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\Microsoft.Xrm.Client.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.0\lib\net40\Microsoft.Xrm.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Client.CodeGeneration, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\Microsoft.Xrm.Client.CodeGeneration.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.0\lib\net40\Microsoft.Xrm.Client.CodeGeneration.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Portal, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\Microsoft.Xrm.Portal.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.0\lib\net40\Microsoft.Xrm.Portal.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Portal.Files, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\Microsoft.Xrm.Portal.Files.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.0\lib\net40\Microsoft.Xrm.Portal.Files.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.0\lib\net40\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.6.1.1\lib\net40\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.6.0.0\lib\net40\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Sdk.Workflow">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.6.1.1\lib\net40\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.6.0.0\lib\net40\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
@@ -131,7 +124,6 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/FakeXrmEasy.2013/packages.config
+++ b/FakeXrmEasy.2013/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
-  <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
-  <package id="Microsoft.CrmSdk.Extensions" version="6.0.4.1" targetFramework="net40" />
-  <package id="Microsoft.CrmSdk.Workflow" version="6.1.1" targetFramework="net4" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.0" allowedVersions="[6.0,7.0)" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.Deployment" version="6.0.0" allowedVersions="[6.0,7.0)" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.Extensions" version="6.0.0" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.Workflow" version="6.0.0" allowedVersions="[6.0,7.0)" targetFramework="net40" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net4" />
+  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="2.0.0.0" targetFramework="net40" />
+  <package id="WindowsAzure.ServiceBus" version="2.1.2.0" targetFramework="net40" />
 </packages>

--- a/FakeXrmEasy.2015.nuspec
+++ b/FakeXrmEasy.2015.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2015 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="7.1.1" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="7.1.1" />
-      <dependency id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="7.0" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="7.0" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="7.0" />
+      <dependency id="Microsoft.CrmSdk.Extensions" version="7.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />

--- a/FakeXrmEasy.2015.nuspec
+++ b/FakeXrmEasy.2015.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2015 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="7.0" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="7.0" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="7.0" />
-      <dependency id="Microsoft.CrmSdk.Extensions" version="7.0" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="7.1" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="7.1" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="7.1" />
+      <dependency id="Microsoft.CrmSdk.Extensions" version="7.1" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />

--- a/FakeXrmEasy.2016.nuspec
+++ b/FakeXrmEasy.2016.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2016 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="8.0" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="8.0" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="8.0" />
-      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.0" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="8.1" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="8.1" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="8.1" />
+      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.1" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />

--- a/FakeXrmEasy.2016.nuspec
+++ b/FakeXrmEasy.2016.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2016 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="8.1.0.2" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" />
-      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.1.0.2" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="8.0" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="8.0" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="8.0" />
+      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />

--- a/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
+++ b/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
@@ -36,17 +36,12 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AntiXSSLibrary, Version=4.2.0.0, Culture=neutral, PublicKeyToken=d127efab8a9c114f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
@@ -60,37 +55,17 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Client, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Client.CodeGeneration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Client.CodeGeneration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Portal, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Portal.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Portal.Files, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Portal.Files.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.1.0.2\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.1.0\lib\net45\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.1.0.2\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.1.0\lib\net45\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.1.0.2\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.1.0.1\lib\net45\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/FakeXrmEasy.2016/packages.config
+++ b/FakeXrmEasy.2016/packages.config
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Workflow" version="8.1.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.1.0.2" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0" allowedVersions="[8.0,8.2)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Deployment" version="8.1.0" allowedVersions="[8.0,8.2)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Workflow" version="8.1.0" allowedVersions="[8.0,8.2)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.1.0.1" allowedVersions="[8.0,8.2)" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net452" />
 </packages>

--- a/FakeXrmEasy.365.nuspec
+++ b/FakeXrmEasy.365.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 365 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" />
-      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2.0.4" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="8.2" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="8.2" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="8.2" />
+      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />

--- a/FakeXrmEasy.365/FakeXrmEasy.365.csproj
+++ b/FakeXrmEasy.365/FakeXrmEasy.365.csproj
@@ -36,17 +36,12 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AntiXSSLibrary, Version=4.2.0.0, Culture=neutral, PublicKeyToken=d127efab8a9c114f, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
@@ -60,37 +55,17 @@
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.22.302111727\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Client, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Client.CodeGeneration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Client.CodeGeneration.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Portal, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Portal.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Microsoft.Xrm.Portal.Files, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\Microsoft.Xrm.Portal.Files.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.2.0\lib\net45\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.2.0\lib\net45\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.2.0.4\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.2.0.1\lib\net45\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/FakeXrmEasy.365/packages.config
+++ b/FakeXrmEasy.365/packages.config
@@ -1,11 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2.0.4" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0" allowedVersions="[8.2,9.0)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Deployment" version="8.2.0" allowedVersions="[8.2,9.0)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Workflow" version="8.2.0" allowedVersions="[8.2,9.0)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2.0.1" allowedVersions="[8.2,9.0)" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net452" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net452" />

--- a/FakeXrmEasy.9.nuspec
+++ b/FakeXrmEasy.9.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 365 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="9.0.0.5" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" />
-      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.5" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="9.0" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="9.0" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="9.0" />
+      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />

--- a/FakeXrmEasy.9/packages.config
+++ b/FakeXrmEasy.9/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.5" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.5" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net452" />
 </packages>

--- a/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
+++ b/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
@@ -42,21 +42,21 @@
       <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Crm.Sdk.Proxy">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.0\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.0\lib\net40\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.6.1.1\lib\net40\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.6.0.0\lib\net40\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Sdk.Workflow">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.6.1.1\lib\net40\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.6.0.0\lib\net40\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -102,29 +102,45 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="bin\Debug\FakeXrmEasy.dll.config" />
+    <None Include="bin\Debug\FakeXrmEasy.Tests.2013.dll.config" />
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="bin\Debug\FakeItEasy.dll" />
+    <Content Include="bin\Debug\FakeItEasy.pdb" />
+    <Content Include="bin\Debug\FakeItEasy.xml" />
+    <Content Include="bin\Debug\FakeXrmEasy.dll" />
+    <Content Include="bin\Debug\FakeXrmEasy.pdb" />
+    <Content Include="bin\Debug\FakeXrmEasy.Tests.2013.dll" />
+    <Content Include="bin\Debug\FakeXrmEasy.Tests.2013.pdb" />
+    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.dll" />
+    <Content Include="bin\Debug\Microsoft.Crm.Sdk.Proxy.xml" />
+    <Content Include="bin\Debug\Microsoft.IdentityModel.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Client.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Client.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Deployment.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.dll" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.Workflow.xml" />
+    <Content Include="bin\Debug\Microsoft.Xrm.Sdk.xml" />
+    <Content Include="bin\Debug\xunit.abstractions.dll" />
+    <Content Include="bin\Debug\xunit.dll" />
+    <Content Include="bin\Debug\xunit.runner.utility.desktop.dll" />
+    <Content Include="bin\Debug\xunit.runner.visualstudio.testadapter.dll" />
+    <Content Include="bin\Debug\xunit.xml" />
+    <Content Include="bin\tools\CrmSvcUtil.exe" />
+    <Content Include="bin\tools\CrmSvcUtil.xml" />
+    <Content Include="bin\tools\Microsoft.Xrm.Sdk.dll" />
+    <Content Include="bin\tools\SolutionPackager.exe" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="bin\Release\" />
+  </ItemGroup>
   <Import Project="..\FakeXrmEasy.Tests.Shared\FakeXrmEasy.Tests.Shared.projitems" Label="Shared" />
-  <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-          <Private>False</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/FakeXrmEasy.Tests.2013/packages.config
+++ b/FakeXrmEasy.Tests.2013/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
-  <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
-  <package id="Microsoft.CrmSdk.Workflow" version="6.1.1" targetFramework="net4" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.0" allowedVersions="[6.0,7.0)" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.Deployment" version="6.0.0" allowedVersions="[6.0,7.0)" targetFramework="net40" />
+  <package id="Microsoft.CrmSdk.Workflow" version="6.0.0" allowedVersions="[6.0,7.0)" targetFramework="net40" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net4" />
   <package id="xunit" version="1.9.2" targetFramework="net40" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net40" />

--- a/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
+++ b/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
@@ -44,8 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
@@ -60,20 +59,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.1.0.2\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.1.0\lib\net45\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.1.0.2\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.1.0\lib\net45\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=2.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.1.0.2\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.1.0.1\lib\net45\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/FakeXrmEasy.Tests.2016/packages.config
+++ b/FakeXrmEasy.Tests.2016/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Workflow" version="8.1.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.1.0.2" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0" allowedVersions="[8.0,8.2)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Deployment" version="8.1.0" allowedVersions="[8.0,8.2)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Workflow" version="8.1.0" allowedVersions="[8.0,8.2)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.1.0.1" allowedVersions="[8.0,8.2)" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
+++ b/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
@@ -44,8 +44,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
@@ -60,20 +59,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.8.2.0\lib\net45\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.2.0.2\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.8.2.0\lib\net45\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=2.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.2.0.4\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.8.2.0.1\lib\net45\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />

--- a/FakeXrmEasy.Tests.365/packages.config
+++ b/FakeXrmEasy.Tests.365/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2.0.4" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0" allowedVersions="[8.2,9.0)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Deployment" version="8.2.0" allowedVersions="[8.2,9.0)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Workflow" version="8.2.0" allowedVersions="[8.2,9.0)" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="8.2.0.1" allowedVersions="[8.2,9.0)" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.9/packages.config
+++ b/FakeXrmEasy.Tests.9/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.5" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.5" targetFramework="net452" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.5" allowedVersions="9.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.22.302111727" targetFramework="net452" />
   <package id="xunit" version="2.0.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/FakeXrmEasy/packages.config
+++ b/FakeXrmEasy/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
-  <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
-  <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
-  <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />
-  <package id="Microsoft.Xrm.Sdk.Workflow.2011" version="5.0.18" targetFramework="net40" />
+  <package id="FakeItEasy" version="3.2.0" allowedVersions="[3.2.0]" targetFramework="net40" />
+  <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" allowedVersions="[5.0,6.0)" targetFramework="net40" />
+  <package id="Microsoft.Xrm.Client.2011" version="5.0.18" allowedVersions="[5.0,6.0)" targetFramework="net40" />
+  <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" allowedVersions="[5.0,6.0)" targetFramework="net40" />
+  <package id="Microsoft.Xrm.Sdk.Workflow.2011" version="5.0.18" allowedVersions="[5.0,6.0)" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
By using the lowest version possible, we increase the number of supported version and reduce the forced upgrade if people are using older versions of NuGet packages.
This still leaves a gap, most noticeable for 8.0 which is not covered at the moment.

Also added the `allowedVersions` attribute in the `packages.config` to prevent people from accidentally upgrading to an out-of-range version.

This is response to #219 