### PR TITLE
Copy the OperationCreatedOn property to the newly created IExecutionContext

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -79,7 +79,6 @@ namespace FakeXrmEasy
                 }
             }
         }
-
         protected IExecutionContext GetFakedExecutionContext(XrmFakedPluginExecutionContext ctx)
         {
             var context = A.Fake<IExecutionContext>();
@@ -151,7 +150,7 @@ namespace FakeXrmEasy
         }
 
         public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, string unsecureConfiguration, string secureConfiguration)
-            where T : class, IPlugin
+            where T : class, IPlugin 
         {
             var pluginType = typeof(T);
             var constructors = pluginType.GetConstructors().ToList();
@@ -164,6 +163,7 @@ namespace FakeXrmEasy
             var pluginInstance = (T)Activator.CreateInstance(typeof(T), unsecureConfiguration, secureConfiguration);
 
             return this.ExecutePluginWithConfigurations(plugCtx, pluginInstance, unsecureConfiguration, secureConfiguration);
+          
         }
 
         public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, T instance, string unsecureConfiguration, string secureConfiguration)
@@ -202,7 +202,7 @@ namespace FakeXrmEasy
         /// <param name="stage">Sets the stage.</param>
         /// <returns></returns>
         public IPlugin ExecutePluginWithTarget<T>(Entity target, string messageName = "Create", int stage = 40)
-            where T : IPlugin, new()
+            where T: IPlugin, new()
         {
             var ctx = GetDefaultPluginContext();
             // Add the target entity to the InputParameters

--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -59,6 +59,7 @@ namespace FakeXrmEasy
             A.CallTo(() => context.SharedVariables).ReturnsLazily(() => ctx.SharedVariables);
             A.CallTo(() => context.BusinessUnitId).ReturnsLazily(() => ctx.BusinessUnitId);
             A.CallTo(() => context.CorrelationId).ReturnsLazily(() => ctx.CorrelationId);
+            A.CallTo(() => context.OperationCreatedOn).ReturnsLazily(() => ctx.OperationCreatedOn);
 
             // Create message will pass an Entity as the target but this is not always true
             // For instance, a Delete request will receive an EntityReference
@@ -78,6 +79,7 @@ namespace FakeXrmEasy
                 }
             }
         }
+
         protected IExecutionContext GetFakedExecutionContext(XrmFakedPluginExecutionContext ctx)
         {
             var context = A.Fake<IExecutionContext>();
@@ -149,7 +151,7 @@ namespace FakeXrmEasy
         }
 
         public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, string unsecureConfiguration, string secureConfiguration)
-            where T : class, IPlugin 
+            where T : class, IPlugin
         {
             var pluginType = typeof(T);
             var constructors = pluginType.GetConstructors().ToList();
@@ -162,7 +164,6 @@ namespace FakeXrmEasy
             var pluginInstance = (T)Activator.CreateInstance(typeof(T), unsecureConfiguration, secureConfiguration);
 
             return this.ExecutePluginWithConfigurations(plugCtx, pluginInstance, unsecureConfiguration, secureConfiguration);
-          
         }
 
         public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, T instance, string unsecureConfiguration, string secureConfiguration)
@@ -201,7 +202,7 @@ namespace FakeXrmEasy
         /// <param name="stage">Sets the stage.</param>
         /// <returns></returns>
         public IPlugin ExecutePluginWithTarget<T>(Entity target, string messageName = "Create", int stage = 40)
-            where T: IPlugin, new()
+            where T : IPlugin, new()
         {
             var ctx = GetDefaultPluginContext();
             // Add the target entity to the InputParameters


### PR DESCRIPTION
Something I noticed while developing is this property not being copied.
Required when deserializing the IExecutionContext (or RemoteExecutionContext) to json using DataContactJsonSerializer. Serializer does not allow DateTime.MinValue.