### PR TITLE
Added a quality of life enhancement to EntityMetadata.SetAttribute

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityMetadataExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityMetadataExtensions.cs
@@ -18,6 +18,10 @@ namespace FakeXrmEasy.Extensions
         public static void SetAttribute(this EntityMetadata entityMetadata, AttributeMetadata attribute)
         {
             var currentAttributes = entityMetadata.Attributes;
+            if (currentAttributes == null)
+            {
+                currentAttributes = new AttributeMetadata[0];
+            }
             var newAttributesList = currentAttributes.Where(a => a.LogicalName != attribute.LogicalName).ToList();
             newAttributesList.Add(attribute);
             var newAttributesArray = newAttributesList.ToArray();

--- a/FakeXrmEasy.Tests.Shared/Extensions/EntityMetadataExtensionsTests.cs
+++ b/FakeXrmEasy.Tests.Shared/Extensions/EntityMetadataExtensionsTests.cs
@@ -38,5 +38,17 @@ namespace FakeXrmEasy.Tests.Extensions
             Assert.Equal("name", entityMetadata.Attributes[0].LogicalName);
             Assert.Equal("name2", entityMetadata.Attributes[1].LogicalName);
         }
+
+        [Fact]
+        public void SetAttribute_should_not_throw_error()
+        {
+            var entityMetadata = new EntityMetadata();
+            var fakeAttribute = new StringAttributeMetadata() { LogicalName = "name" };
+
+
+            entityMetadata.SetAttribute(fakeAttribute);
+            Assert.Equal(1, entityMetadata.Attributes.Length);
+            Assert.Equal("name", entityMetadata.Attributes[0].LogicalName);
+        }
     }
 }


### PR DESCRIPTION
If currentAttributes is null it will be set to an empty array before attempting to add an item to the list