### PR TITLE
Polishing IXrmContext

### DIFF
--- a/FakeXrmEasy.Shared/IXrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/IXrmFakedContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Xrm.Sdk;
+using System;
 using System.Activities;
 using System.Collections.Generic;
 using System.Linq;
@@ -56,10 +57,31 @@ namespace FakeXrmEasy
             where T : IPlugin, new();
 
         /// <summary>
+        /// Returns a faked plugin that will be executed against this faked context and the entity passed as the target
+        /// </summary>
+        /// <returns></returns>
+        IPlugin ExecutePluginWithTarget(IPlugin instance, Entity target, string messageName = "Create", int stage = 40);
+
+        /// <summary>
+        /// Returns a faked plugin that will be executed against this faked context and the entity passed as the target
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        IPlugin ExecutePluginWithTargetReference<T>(EntityReference target, string messageName = "Create", int stage = 40)
+            where T : IPlugin, new();
+
+        /// <summary>
+        /// Returns a faked plugin that will be executed against this faked context and the entity passed as the target
+        /// </summary>
+        /// <returns></returns>
+        IPlugin ExecutePluginWithTargetReference(IPlugin instance, EntityReference target, string messageName = "Create", int stage = 40);
+
+        /// <summary>
         /// Returns a faked plugin with a target and the specified pre entity images
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
+        [Obsolete]
         IPlugin ExecutePluginWithTargetAndPreEntityImages<T>(object target, EntityImageCollection preEntityImages, string messageName = "Create", int stage = 40)
             where T : IPlugin, new();
 
@@ -68,6 +90,7 @@ namespace FakeXrmEasy
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
+        [Obsolete]
         IPlugin ExecutePluginWithTargetAndPostEntityImages<T>(object target, EntityImageCollection postEntityImages, string messageName = "Create", int stage = 40)
             where T : IPlugin, new();
 
@@ -94,8 +117,13 @@ namespace FakeXrmEasy
         IPlugin ExecutePluginWith<T>(XrmFakedPluginExecutionContext ctx)
             where T : IPlugin, new();
 
-        IPlugin ExecutePluginWith<T>(XrmFakedPluginExecutionContext ctx, T instance)
-            where T : IPlugin, new();
+        /// <summary>
+        /// Executes a plugin passing a custom context. This is useful whenever we need to mock more complex plugin contexts (ex: passing MessageName, plugin Depth, InitiatingUserId etc...)
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="instance"></param>
+        /// <returns></returns>
+        IPlugin ExecutePluginWith(XrmFakedPluginExecutionContext ctx, IPlugin instance);
 
         /// <summary>
         /// Executes a plugin with a custom context and custom configurations (configurations aren't inherent properties of the context so they need to be passed separately)
@@ -110,6 +138,7 @@ namespace FakeXrmEasy
                                      string secureConfiguration)
             where T : class, IPlugin;
 
+        [Obsolete("Use ExecutePluginWith(XrmFakedPluginExecutionContext ctx, IPlugin instance).")]
         IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, T instance, string unsecureConfiguration, string secureConfiguration)
             where T : class, IPlugin;
 

--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -7,6 +7,10 @@ namespace FakeXrmEasy
 {
     public partial class XrmFakedContext : IXrmContext
     {
+        /// <summary>
+        /// Returns a plugin context with default properties one can override
+        /// </summary>
+        /// <returns></returns>
         public XrmFakedPluginExecutionContext GetDefaultPluginContext()
         {
             var userId = CallerId?.Id ?? Guid.NewGuid();
@@ -81,6 +85,7 @@ namespace FakeXrmEasy
                 }
             }
         }
+
         protected IExecutionContext GetFakedExecutionContext(XrmFakedPluginExecutionContext ctx)
         {
             var context = A.Fake<IExecutionContext>();
@@ -89,9 +94,31 @@ namespace FakeXrmEasy
 
             return context;
         }
-
-        public IPlugin ExecutePluginWith<T>(XrmFakedPluginExecutionContext ctx, T instance)
+        
+        /// <summary>
+        /// Executes a plugin passing a custom context. This is useful whenever we need to mock more complex plugin contexts (ex: passing MessageName, plugin Depth, InitiatingUserId etc...)
+        /// </summary>
+        /// <typeparam name="T">Must be a plugin</typeparam>
+        /// <param name="ctx"></param>
+        /// <returns></returns>
+        public IPlugin ExecutePluginWith<T>(XrmFakedPluginExecutionContext ctx = null)
             where T : IPlugin, new()
+        {
+            if (ctx == null)
+            {
+                ctx = GetDefaultPluginContext();
+            }
+
+            return this.ExecutePluginWith(ctx, new T());
+        }
+
+        /// <summary>
+        /// Executes a plugin passing a custom context. This is useful whenever we need to mock more complex plugin contexts (ex: passing MessageName, plugin Depth, InitiatingUserId etc...)
+        /// </summary>
+        /// <param name="ctx"></param>
+        /// <param name="instance"></param>
+        /// <returns></returns>
+        public IPlugin ExecutePluginWith(XrmFakedPluginExecutionContext ctx, IPlugin instance)
         {
             var fakedServiceProvider = GetFakedServiceProvider(ctx);
 
@@ -105,27 +132,6 @@ namespace FakeXrmEasy
 
             fakedPlugin.Execute(fakedServiceProvider); //Execute the plugin
             return fakedPlugin;
-        }
-
-        public IPlugin ExecutePluginWith<T>(XrmFakedPluginExecutionContext ctx = null)
-            where T : IPlugin, new()
-        {
-            if (ctx == null)
-            {
-                ctx = GetDefaultPluginContext();
-            }
-
-            return this.ExecutePluginWith(ctx, new T());
-        }
-
-        public IPlugin ExecutePluginWithTarget<T>(XrmFakedPluginExecutionContext ctx, Entity target, string messageName = "Create", int stage = 40)
-            where T : IPlugin, new()
-        {
-            ctx.InputParameters.Add("Target", target);
-            ctx.MessageName = messageName;
-            ctx.Stage = stage;
-
-            return this.ExecutePluginWith<T>(ctx);
         }
 
         public IPlugin ExecutePluginWith<T>(ParameterCollection inputParameters, ParameterCollection outputParameters, EntityImageCollection preEntityImages, EntityImageCollection postEntityImages)
@@ -152,7 +158,7 @@ namespace FakeXrmEasy
         }
 
         public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, string unsecureConfiguration, string secureConfiguration)
-            where T : class, IPlugin 
+            where T : class, IPlugin
         {
             var pluginType = typeof(T);
             var constructors = pluginType.GetConstructors().ToList();
@@ -164,11 +170,11 @@ namespace FakeXrmEasy
 
             var pluginInstance = (T)Activator.CreateInstance(typeof(T), unsecureConfiguration, secureConfiguration);
 
-            return this.ExecutePluginWithConfigurations(plugCtx, pluginInstance, unsecureConfiguration, secureConfiguration);
-          
+            return this.ExecutePluginWith(plugCtx, pluginInstance);
         }
 
-        public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, T instance, string unsecureConfiguration, string secureConfiguration)
+        [Obsolete("Use ExecutePluginWith(XrmFakedPluginExecutionContext ctx, IPlugin instance).")]
+        public IPlugin ExecutePluginWithConfigurations<T>(XrmFakedPluginExecutionContext plugCtx, T instance, string unsecureConfiguration="", string secureConfiguration="")
             where T : class, IPlugin
         {
             var fakedServiceProvider = GetFakedServiceProvider(plugCtx);
@@ -194,6 +200,16 @@ namespace FakeXrmEasy
             return fakedPlugin;
         }
 
+        public IPlugin ExecutePluginWithTarget<T>(XrmFakedPluginExecutionContext ctx, Entity target, string messageName = "Create", int stage = 40)
+          where T : IPlugin, new()
+        {
+            ctx.InputParameters.Add("Target", target);
+            ctx.MessageName = messageName;
+            ctx.Stage = stage;
+
+            return this.ExecutePluginWith<T>(ctx);
+        }
+
         /// <summary>
         /// Executes the plugin of type T against the faked context for an entity target
         /// and returns the faked plugin
@@ -204,15 +220,30 @@ namespace FakeXrmEasy
         /// <param name="stage">Sets the stage.</param>
         /// <returns></returns>
         public IPlugin ExecutePluginWithTarget<T>(Entity target, string messageName = "Create", int stage = 40)
-            where T: IPlugin, new()
+            where T : IPlugin, new()
+        {
+            return this.ExecutePluginWithTarget(new T(), target, messageName, stage);
+        }
+
+        /// <summary>
+        /// Executes the plugin of type T against the faked context for an entity target
+        /// and returns the faked plugin
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="target">The entity to execute the plug-in for.</param>
+        /// <param name="messageName">Sets the message name.</param>
+        /// <param name="stage">Sets the stage.</param>
+        /// <returns></returns>
+        public IPlugin ExecutePluginWithTarget(IPlugin instance, Entity target, string messageName = "Create", int stage = 40)
         {
             var ctx = GetDefaultPluginContext();
+
             // Add the target entity to the InputParameters
             ctx.InputParameters.Add("Target", target);
             ctx.MessageName = messageName;
             ctx.Stage = stage;
 
-            return this.ExecutePluginWith<T>(ctx);
+            return this.ExecutePluginWith(ctx, instance);
         }
 
         /// <summary>
@@ -227,15 +258,35 @@ namespace FakeXrmEasy
         public IPlugin ExecutePluginWithTargetReference<T>(EntityReference target, string messageName = "Delete", int stage = 40)
             where T : IPlugin, new()
         {
+            return this.ExecutePluginWithTargetReference(new T(), target, messageName, stage);
+        }
+
+        /// <summary>
+        /// Executes the plugin of type T against the faked context for an entity reference target
+        /// and returns the faked plugin
+        /// </summary>
+        /// <param name="instance"></param>
+        /// <param name="target">The entity reference to execute the plug-in for.</param>
+        /// <param name="messageName">Sets the message name.</param>
+        /// <param name="stage">Sets the stage.</param>
+        /// <returns></returns>
+        public IPlugin ExecutePluginWithTargetReference(IPlugin instance, EntityReference target, string messageName = "Delete", int stage = 40)
+        {
             var ctx = GetDefaultPluginContext();
             // Add the target entity to the InputParameters
             ctx.InputParameters.Add("Target", target);
             ctx.MessageName = messageName;
             ctx.Stage = stage;
 
-            return this.ExecutePluginWith<T>(ctx);
+            return this.ExecutePluginWith(ctx, instance);
         }
 
+        /// <summary>
+        /// Returns a faked plugin with a target and the specified pre entity images
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        [Obsolete]
         public IPlugin ExecutePluginWithTargetAndPreEntityImages<T>(object target, EntityImageCollection preEntityImages, string messageName = "Create", int stage = 40)
             where T : IPlugin, new()
         {
@@ -249,6 +300,12 @@ namespace FakeXrmEasy
             return this.ExecutePluginWith<T>(ctx);
         }
 
+        /// <summary>
+        /// Returns a faked plugin with a target and the specified post entity images
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        [Obsolete]
         public IPlugin ExecutePluginWithTargetAndPostEntityImages<T>(object target, EntityImageCollection postEntityImages, string messageName = "Create", int stage = 40)
             where T : IPlugin, new()
         {
@@ -262,6 +319,7 @@ namespace FakeXrmEasy
             return this.ExecutePluginWith<T>(ctx);
         }
 
+        [Obsolete]
         public IPlugin ExecutePluginWithTargetAndInputParameters<T>(Entity target, ParameterCollection inputParameters, string messageName = "Create", int stage = 40)
             where T : IPlugin, new()
         {

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestPlugins.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestPlugins.cs
@@ -164,7 +164,7 @@ namespace FakeXrmEasy.Tests
             var plugCtx = fakedContext.GetDefaultPluginContext();
             plugCtx.InputParameters = inputParams;
 
-            fakedContext.ExecutePluginWith<TestPropertiesPlugin>(plugCtx, plugin);
+            fakedContext.ExecutePluginWith(plugCtx, plugin);
             Assert.Equal("Property Updated", plugin.Property);
         }
 

--- a/FakeXrmEasy/Properties/AssemblyInfo.cs
+++ b/FakeXrmEasy/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("1.47.0.0")]
 [assembly: AssemblyFileVersion("1.47.0.0")]
-[assembly: AssemblyInformationalVersion("1.47.0.0 - master - 2c4d88")]
+[assembly: AssemblyInformationalVersion("1.47.0.0 - XrmContext-Polish - ecf66f")]


### PR DESCRIPTION
- Removed unused parameters and deprecated some old ExecutePluginWith* methods.
- Removed the generic type on methods that accept a plugin instance since the type wasn't used
- Copied some documentation from IXrmContext to XrmFakedContext because intellisense works based on the type