### PR TITLE
Fix for avg, min and max Aggregate FetchXml with null values 

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Aggregations.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Aggregations.cs
@@ -266,20 +266,38 @@ namespace FakeXrmEasy
         {
             public override object AggregateValues(IEnumerable<object> values)
             {
-                var lst = values.ToList();
-                // TODO: Check these cases in CRM proper
-                if (lst.Count == 0) return null;
-                if (lst.All(x => x == null)) return null;
-
+                var lst = values.Where(x=>x!=null);
+                if (!lst.Any()) return null;
+               
                 var firstValue = lst.Where(x => x != null).First();
                 var valType = firstValue.GetType();
 
-                if (valType == typeof(Money))
+                if (valType == typeof(decimal) || valType == typeof(decimal?))
                 {
-                    return new Money(values.Select(x => (x as Money)?.Value ?? 0m).Min());
+                    return lst.Min(x => (decimal)x);
                 }
 
-                return values.Select(x => x ?? 0).Min();
+                if (valType == typeof(Money))
+                {
+                    return new Money(lst.Min(x => (x as Money).Value));
+                }
+
+                if (valType == typeof(int) || valType == typeof(int?))
+                {
+                    return lst.Min(x => (int)x);
+                }
+
+                if (valType == typeof(float) || valType == typeof(float?))
+                {
+                    return lst.Min(x => (float)x);
+                }
+
+                if (valType == typeof(double) || valType == typeof(double?))
+                {
+                    return lst.Min(x => (double)x);
+                }
+
+                throw new Exception("Unhndled property type '" + valType.FullName + "' in 'min' aggregate");
             }
         }
 
@@ -287,20 +305,38 @@ namespace FakeXrmEasy
         {
             public override object AggregateValues(IEnumerable<object> values)
             {
-                var lst = values.ToList();
-                // TODO: Check these cases in CRM proper
-                if (lst.Count == 0) return null;
-                if (lst.All(x => x == null)) return null;
-
-                var firstValue = lst.Where(x => x != null).First();
+                var lst = values.Where(x=>x!=null);
+                if (!lst.Any()) return null;
+              
+                var firstValue = lst.First();
                 var valType = firstValue.GetType();
+
+                if (valType == typeof(decimal) || valType == typeof(decimal?))
+                {
+                    return lst.Max(x => (decimal)x);
+                }
 
                 if (valType == typeof(Money))
                 {
-                    return new Money(values.Select(x => (x as Money)?.Value ?? 0m).Max());
+                    return new Money(lst.Max(x => (x as Money).Value));
                 }
 
-                return values.Select(x => x ?? 0).Max();
+                if (valType == typeof(int) || valType == typeof(int?))
+                {
+                    return lst.Max(x => (int)x);
+                }
+
+                if (valType == typeof(float) || valType == typeof(float?))
+                {
+                    return lst.Max(x => (float)x);
+                }
+
+                if (valType == typeof(double) || valType == typeof(double?))
+                {
+                    return lst.Max(x => (double)x);
+                }
+
+                throw new Exception("Unhndled property type '" + valType.FullName + "' in 'max' aggregate");
             }
         }
 
@@ -308,36 +344,35 @@ namespace FakeXrmEasy
         {
             public override object AggregateValues(IEnumerable<object> values)
             {
-                var lst = values.ToList();
-                // TODO: Check these cases in CRM proper
-                if (lst.Count == 0) return null;
-                if (lst.All(x => x == null)) return null;
-
-                var firstValue = lst.Where(x => x != null).First();
+                var lst = values.Where(x=>x!=null);
+                if (!lst.Any()) return null;
+                
+                var firstValue = lst.First();
                 var valType = firstValue.GetType();
 
                 if (valType == typeof(decimal) || valType == typeof(decimal?))
                 {
-                    return lst.Average(x => x as decimal? ?? 0m);
+                    return lst.Average(x => (decimal)x );
                 }
+
                 if (valType == typeof(Money))
                 {
-                    return new Money(lst.Average(x => (x as Money)?.Value ?? 0m));
+                    return new Money(lst.Average(x => (x as Money).Value));
                 }
 
                 if (valType == typeof(int) || valType == typeof(int?))
                 {
-                    return lst.Average(x => x as int? ?? 0);
+                    return lst.Average(x => (int)x );
                 }
 
                 if (valType == typeof(float) || valType == typeof(float?))
                 {
-                    return lst.Average(x => x as float? ?? 0f);
+                    return lst.Average(x => (float)x);
                 }
 
                 if (valType == typeof(double) || valType == typeof(double?))
                 {
-                    return lst.Average(x => x as double? ?? 0d);
+                    return lst.Average(x => (double)x);
                 }
 
                 throw new Exception("Unhndled property type '" + valType.FullName + "' in 'avg' aggregate");

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/AggregateTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FetchXml/AggregateTests.cs
@@ -340,6 +340,117 @@ namespace FakeXrmEasy.Tests.FakeContextTests.FetchXml
         }
 
         [Fact]
+        public void FetchXml_Aggregate_Min_With_Nulls()
+        {
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+            List<Entity> initialEntities = new List<Entity>();
+
+            Entity e = new Entity("entity");
+            e.Id = Guid.NewGuid();
+            e["value"] = 1;
+            initialEntities.Add(e);
+
+            Entity e2 = new Entity("entity");
+            e2.Id = Guid.NewGuid();
+            e2["value"] = 2;
+            initialEntities.Add(e2);
+
+            Entity e3 = new Entity("entity");
+            e3.Id = Guid.NewGuid();
+            e3["value"] = null;
+            initialEntities.Add(e3);
+
+            context.Initialize(initialEntities);
+
+            FetchExpression query = new FetchExpression($@"
+                <fetch aggregate='true' >
+                  <entity name='entity' >
+                    <attribute name='value' alias='minvalue' aggregate='min' />
+                  </entity>
+                </fetch>
+                ");
+
+            EntityCollection result = service.RetrieveMultiple(query);
+            Assert.Equal(1, result.Entities.Count);
+            Assert.Equal(1, result.Entities.Single().GetAttributeValue<AliasedValue>("minvalue").Value);
+        }
+
+        [Fact]
+        public void FetchXml_Aggregate_Max_With_Nulls()
+        {
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+            List<Entity> initialEntities = new List<Entity>();
+
+            Entity e = new Entity("entity");
+            e.Id = Guid.NewGuid();
+            e["value"] = -0.5m;
+            initialEntities.Add(e);
+
+            Entity e2 = new Entity("entity");
+            e2.Id = Guid.NewGuid();
+            e2["value"] = -2m;
+            initialEntities.Add(e2);
+
+            Entity e3 = new Entity("entity");
+            e3.Id = Guid.NewGuid();
+            e3["value"] = null;
+            initialEntities.Add(e3);
+
+            context.Initialize(initialEntities);
+
+            FetchExpression query = new FetchExpression($@"
+                <fetch aggregate='true' >
+                  <entity name='entity' >
+                    <attribute name='value' alias='maxvalue' aggregate='max' />
+                  </entity>
+                </fetch>
+                ");
+
+            EntityCollection result = service.RetrieveMultiple(query);
+            Assert.Equal(1, result.Entities.Count);
+            Assert.Equal(-0.5m, result.Entities.Single().GetAttributeValue<AliasedValue>("maxvalue").Value);
+        }
+
+        [Fact]
+        public void FetchXml_Aggregate_Avg_With_Nulls()
+        {
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+            List<Entity> initialEntities = new List<Entity>();
+
+            Entity e = new Entity("entity");
+            e.Id = Guid.NewGuid();
+            e["value"] = -1m;
+            initialEntities.Add(e);
+
+            Entity e2 = new Entity("entity");
+            e2.Id = Guid.NewGuid();
+            e2["value"] = -2m;
+            initialEntities.Add(e2);
+
+            Entity e3 = new Entity("entity");
+            e3.Id = Guid.NewGuid();
+            e3["value"] = null;
+            initialEntities.Add(e3);
+
+            context.Initialize(initialEntities);
+
+            FetchExpression query = new FetchExpression($@"
+                <fetch aggregate='true' >
+                  <entity name='entity' >
+                    <attribute name='value' alias='avgvalue' aggregate='avg' />
+                  </entity>
+                </fetch>
+                ");
+
+            EntityCollection result = service.RetrieveMultiple(query);
+            Assert.Equal(1, result.Entities.Count);
+            Assert.Equal(-1.5m, result.Entities.Single().GetAttributeValue<AliasedValue>("avgvalue").Value);
+        }
+
+        [Fact]
         public void Query_Should_Return_QuoteProduct_Counts()
         {
             var context = new XrmFakedContext();


### PR DESCRIPTION
Hi @jordimontana82,
I fixed the aggregate FetchXml queries to behave in the same way the CRM does, which is ignoring null values. The current implementation defaulted null values to 0 instead of ignoring them and was producing wrong values for the aggregates. I didn't change the sum aggregate because it is in a working state, but maybe i should have refactored that too so the methods would be similar.

Best regards, 
@BetimBeja 
Closes #355