### PR TITLE
Validate references to other entities

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -133,8 +133,17 @@ namespace FakeXrmEasy
                     {
                         cachedEntity[sAttributeName] = ConvertToUtc((DateTime)e[sAttributeName]);
                     }
+
                     else
                     {
+                        if (attribute is EntityReference && ValidateReferences)
+                        {
+                            var target = (EntityReference)e[sAttributeName];
+                            if (!Data.ContainsKey(target.LogicalName) || !Data[target.LogicalName].ContainsKey(target.Id))
+                            {
+                                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{target.LogicalName} With Id = {target.Id:D} Does Not Exist");
+                            }
+                        }
                         cachedEntity[sAttributeName] = attribute;
                     }
                 }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/ValidateReferencesTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/ValidateReferencesTests.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.Text;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.FakeContextTests
+{
+    public class ValidateReferencesTests
+    {
+        [Fact]
+        public void When_context_is_initialised_validate_references_is_disabled_by_default()
+        {
+            var context = new XrmFakedContext();
+            Assert.False(context.ValidateReferences);
+        }
+
+        [Fact]
+        public void An_entity_which_references_another_non_existent_entity_can_be_created_when_validate_is_false()
+        {
+            var context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+
+            Guid otherEntity = Guid.NewGuid();
+            Entity entity = new Entity("entity");
+
+            entity["otherEntity"] = new EntityReference("entity", otherEntity);
+
+            Guid created = service.Create(entity);
+
+            var ex = Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Retrieve("entity", otherEntity, new ColumnSet(true)));
+
+            Assert.NotEqual(Guid.Empty, created);
+            Assert.Equal($"{entity.LogicalName} With Id = {otherEntity:D} Does Not Exist", ex.Message);
+        }
+
+        [Fact]
+        public void An_entity_which_references_another_non_existent_entity_can_not_be_created_when_validate_is_true()
+        {
+            var context = new XrmFakedContext();
+            context.ValidateReferences = true;
+            IOrganizationService service = context.GetOrganizationService();
+
+            Guid otherEntity = Guid.NewGuid();
+            Entity entity = new Entity("entity");
+
+            entity["otherEntity"] = new EntityReference("entity", otherEntity);
+
+            var ex = Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Create(entity));
+
+            Assert.Equal($"{entity.LogicalName} With Id = {otherEntity:D} Does Not Exist", ex.Message);
+        }
+
+        [Fact]
+        public void An_entity_which_references_another_existent_entity_can_be_created_when_validate_is_true()
+        {
+            var context = new XrmFakedContext();
+            context.ValidateReferences = true;
+            IOrganizationService service = context.GetOrganizationService();
+
+            Entity otherEntity = new Entity("otherEntity");
+            otherEntity.Id = Guid.NewGuid();
+            context.Initialize(otherEntity);
+
+            Entity entity = new Entity("entity");
+            entity["otherEntity"] = otherEntity.ToEntityReference();
+
+            Guid created = service.Create(entity);
+
+            Entity otherEntityInContext = service.Retrieve("otherEntity", otherEntity.Id, new ColumnSet(true));
+
+            Assert.NotEqual(Guid.Empty, created);
+            Assert.Equal(otherEntity.Id, otherEntityInContext.Id);
+        }
+    }
+}

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/ValidateReferencesTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/ValidateReferencesTests.cs
@@ -74,5 +74,69 @@ namespace FakeXrmEasy.Tests.FakeContextTests
             Assert.NotEqual(Guid.Empty, created);
             Assert.Equal(otherEntity.Id, otherEntityInContext.Id);
         }
+
+        [Fact]
+        public void An_entity_which_references_another_non_existent_entity_can_be_updated_when_validate_is_false()
+        {
+            var context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+
+            Entity entity = new Entity("entity");
+            entity.Id = Guid.NewGuid();
+            context.Initialize(entity);
+
+            Guid otherEntityId = Guid.NewGuid();
+            entity["otherEntity"] = new EntityReference("entity", otherEntityId);
+
+            service.Update(entity);
+
+            Entity updated = service.Retrieve(entity.LogicalName, entity.Id, new ColumnSet(true));
+            var ex = Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Retrieve("entity", otherEntityId, new ColumnSet(true)));
+            Assert.Equal(otherEntityId, updated.GetAttributeValue<EntityReference>("otherEntity").Id);
+            Assert.Equal($"{entity.LogicalName} With Id = {otherEntityId:D} Does Not Exist", ex.Message);
+        }
+
+        [Fact]
+        public void An_entity_which_references_another_non_existent_entity_can_not_be_updated_when_validate_is_true()
+        {
+            var context = new XrmFakedContext();
+            context.ValidateReferences = true;
+            IOrganizationService service = context.GetOrganizationService();
+
+            Entity entity = new Entity("entity");
+            entity.Id = Guid.NewGuid();
+            context.Initialize(entity);
+
+            Guid otherEntityId = Guid.NewGuid();
+            entity["otherEntity"] = new EntityReference("entity", otherEntityId);
+
+            var ex = Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Update(entity));
+            Assert.Equal($"{entity.LogicalName} With Id = {otherEntityId:D} Does Not Exist", ex.Message);
+        }
+
+        [Fact]
+        public void An_entity_which_references_another_existent_entity_can_be_updated_when_validate_is_true()
+        {
+            var context = new XrmFakedContext();
+            context.ValidateReferences = true;
+            IOrganizationService service = context.GetOrganizationService();
+
+            Entity otherEntity = new Entity("otherEntity");
+            otherEntity.Id = Guid.NewGuid();
+
+            Entity entity = new Entity("entity");
+            entity.Id = Guid.NewGuid();
+
+            context.Initialize(new Entity[] { otherEntity, entity });
+            entity["otherEntity"] = otherEntity.ToEntityReference();
+
+            service.Update(entity);
+
+            Entity otherEntityInContext = service.Retrieve("otherEntity", otherEntity.Id, new ColumnSet(true));
+            Entity updated = service.Retrieve(entity.LogicalName, entity.Id, new ColumnSet(true));
+
+            Assert.Equal(otherEntity.Id, updated.GetAttributeValue<EntityReference>("otherEntity").Id);
+            Assert.Equal(otherEntity.Id, otherEntityInContext.Id);
+        }
     }
 }

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -92,6 +92,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\OperatorTests\MultiSelectOptionSet\MultiSelectOptionSetTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\OperatorTests\Strings\StringOperatorsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\TranslateQueryExpressionTests\OrderByTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\ValidateReferencesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\WhoAmIRequest\WhoAmITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\WinOpportunityRequestTests\WinOpportunityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\XrmFakedRelationshipTests.cs" />


### PR DESCRIPTION
Hello Jordi,
I added a property ValidateReferences on the context and if this property is true then references to other entities are validated (if they exist) on create or update of an entity.
There is one [fix](https://github.com/BetimBeja/fake-xrm-easy/blob/f33bfe3ca2e87357fa1be67bf696c63594fdd575/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs#L260-L270) that I am not sure if should have been done in another way.

Best regards,
Betim.

Closes #204 