### PR TITLE
Hotfix for QueryByAttribute paging

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveMultipleRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveMultipleRequestExecutor.cs
@@ -62,6 +62,8 @@ namespace FakeXrmEasy.FakeMessageExecutors
                     qe.Criteria.AddCondition(new ConditionExpression(query.Attributes[i], ConditionOperator.Equal, query.Values[i]));
                 }
 
+                qe.PageInfo = query.PageInfo;
+
                 // QueryExpression now done... execute it!
                 var linqQuery = XrmFakedContext.TranslateQueryExpressionToLinq(ctx, qe);
                 list = linqQuery.ToList();

--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -400,7 +400,13 @@ namespace FakeXrmEasy
                     var response = executor.Execute(request, context) as RetrieveMultipleResponse;
 
                     QueryExpression qe = req as QueryExpression;
-                    if (qe?.PageInfo.ReturnTotalRecordCount == true)
+                    if (qe?.PageInfo?.ReturnTotalRecordCount == true)
+                    {
+                        response.EntityCollection.TotalRecordCount = response.EntityCollection.Entities.Count;
+                    }
+
+                    QueryByAttribute qa = req as QueryByAttribute;
+                    if (qa?.PageInfo?.ReturnTotalRecordCount == true)
                     {
                         response.EntityCollection.TotalRecordCount = response.EntityCollection.Entities.Count;
                     }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/QueryByAttribute/QueryByAttributeTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/QueryByAttribute/QueryByAttributeTests.cs
@@ -113,5 +113,72 @@ namespace FakeXrmEasy.Tests.FakeContextTests.QueryByAttributeTests
             Assert.True(results.Entities[0].Attributes.ContainsKey("lastname"));
             Assert.False(results.Entities[0].Attributes.ContainsKey("firstname"));
         }
+
+        [Fact]
+        public static void Page_info_is_respected_for_query_by_attribute()
+        {
+            var fakedContext = new XrmFakedContext();
+            var fakedService = fakedContext.GetFakedOrganizationService();
+
+            var contact1 = new Contact
+            {
+                Id = Guid.NewGuid(),
+                LastName = "asdf"
+            };
+
+            var contact2 = new Contact
+            {
+                Id = Guid.NewGuid(),
+                LastName = "qwer"
+            };
+
+            fakedContext.Initialize(new List<Entity> { contact1, contact2 });
+
+            QueryByAttribute query = new QueryByAttribute("contact");
+            query.ColumnSet = new ColumnSet("firstname", "lastname");
+            query.PageInfo = new PagingInfo()
+            {
+                PageNumber = 1,
+                Count = 1,
+            };
+            var results = fakedService.RetrieveMultiple(query);
+
+            Assert.True(results.MoreRecords);
+            Assert.NotNull(results.PagingCookie);
+        }
+
+        [Fact]
+        public static void Return_total_record_count_is_respected_for_query_by_attribute()
+        {
+            var fakedContext = new XrmFakedContext();
+            var fakedService = fakedContext.GetFakedOrganizationService();
+
+            var contact1 = new Contact
+            {
+                Id = Guid.NewGuid(),
+                LastName = "asdf"
+            };
+
+            var contact2 = new Contact
+            {
+                Id = Guid.NewGuid(),
+                LastName = "qwer"
+            };
+
+            fakedContext.Initialize(new List<Entity> { contact1, contact2 });
+
+            QueryByAttribute query = new QueryByAttribute("contact");
+            query.ColumnSet = new ColumnSet("firstname", "lastname");
+            query.PageInfo = new PagingInfo()
+            {
+                //TODO: Fix TotalRecordCount calculations
+                //PageNumber = 1,
+                //Count = 1,
+                ReturnTotalRecordCount = true
+            };
+            var results = fakedService.RetrieveMultiple(query);
+
+            Assert.Equal(2, results.TotalRecordCount);
+        }
     }
 }


### PR DESCRIPTION
To Do: Calculate TotalRecordCount in the same place there doing paging