### PR TITLE
EntityReference Name is populated when metadata is provided

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -155,7 +155,7 @@ namespace FakeXrmEasy.Extensions
 
                     if (e.Attributes.ContainsKey(attKey) && e.Attributes[attKey] != null)
                     {
-                        projected[attKey] = CloneAttribute(e[attKey]);
+                        projected[attKey] = CloneAttribute(e[attKey], context);
 
                         string formattedValue = "";
 
@@ -181,7 +181,7 @@ namespace FakeXrmEasy.Extensions
             }
         }
 
-        public static object CloneAttribute(object attributeValue)
+        public static object CloneAttribute(object attributeValue, XrmFakedContext context = null)
         {
             if (attributeValue == null)
                 return null;
@@ -197,7 +197,16 @@ namespace FakeXrmEasy.Extensions
             {
                 var original = (attributeValue as EntityReference);
                 var clone = new EntityReference(original.LogicalName, original.Id);
-                clone.Name = CloneAttribute(original.Name) as string;
+
+                if (context != null && !string.IsNullOrEmpty(original.LogicalName) && context.EntityMetadata.ContainsKey(original.LogicalName) && !string.IsNullOrEmpty(context.EntityMetadata[original.LogicalName].PrimaryNameAttribute) &&
+                    context.Data.ContainsKey(original.LogicalName) && context.Data[original.LogicalName].ContainsKey(original.Id))
+                {
+                    clone.Name = context.Data[original.LogicalName][original.Id].GetAttributeValue<string>(context.EntityMetadata[original.LogicalName].PrimaryNameAttribute);
+                }
+                else
+                {
+                    clone.Name = CloneAttribute(original.Name) as string;
+                }
 
 #if !FAKE_XRM_EASY && !FAKE_XRM_EASY_2013 && !FAKE_XRM_EASY_2015
                 if (original.KeyAttributes != null)
@@ -206,7 +215,7 @@ namespace FakeXrmEasy.Extensions
                     clone.KeyAttributes.AddRange(original.KeyAttributes.Select(kvp => new KeyValuePair<string, object>(CloneAttribute(kvp.Key) as string, kvp.Value)).ToArray());
                 }
 #endif
-                    return clone;
+                return clone;
             }
             else if (type == typeof(BooleanManagedProperty))
             {
@@ -279,7 +288,7 @@ namespace FakeXrmEasy.Extensions
             throw new Exception(string.Format("Attribute type not supported when trying to clone attribute '{0}'", type.ToString()));
         }
 
-        public static Entity Clone(this Entity e)
+        public static Entity Clone(this Entity e, XrmFakedContext context = null)
         {
             var cloned = new Entity(e.LogicalName);
             cloned.Id = e.Id;
@@ -296,7 +305,7 @@ namespace FakeXrmEasy.Extensions
 
             foreach (var attKey in e.Attributes.Keys)
             {
-                cloned[attKey] = e[attKey] != null ? CloneAttribute(e[attKey]) : null;
+                cloned[attKey] = e[attKey] != null ? CloneAttribute(e[attKey], context) : null;
             }
 #if !FAKE_XRM_EASY && !FAKE_XRM_EASY_2013 && !FAKE_XRM_EASY_2015
             foreach (var attKey in e.KeyAttributes.Keys)
@@ -312,10 +321,10 @@ namespace FakeXrmEasy.Extensions
             return (T)e.Clone(typeof(T));
         }
 
-        public static Entity Clone(this Entity e, Type t)
+        public static Entity Clone(this Entity e, Type t, XrmFakedContext context = null)
         {
             if (t == null)
-                return e.Clone();
+                return e.Clone(context);
 
             var cloned = Activator.CreateInstance(t) as Entity;
             cloned.Id = e.Id;
@@ -334,7 +343,7 @@ namespace FakeXrmEasy.Extensions
             {
                 if (e[attKey] != null)
                 {
-                    cloned[attKey] = CloneAttribute(e[attKey]);
+                    cloned[attKey] = CloneAttribute(e[attKey], context);
                 }
             }
 
@@ -529,6 +538,6 @@ namespace FakeXrmEasy.Extensions
             return result;
         }
 
-        
+
     }
 }

--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -124,7 +124,7 @@ namespace FakeXrmEasy
                         && context.Data[entityName].ContainsKey(id))
                     {
                         //Entity found => return only the subset of columns specified or all of them
-                        var foundEntity = context.Data[entityName][id].Clone(reflectedType);
+                        var foundEntity = context.Data[entityName][id].Clone(reflectedType, context);
                         if (columnSet.AllColumns)
                         {
                             foundEntity.ApplyDateBehaviour(context);
@@ -244,7 +244,7 @@ namespace FakeXrmEasy
         protected EntityReference ResolveEntityReferenceByAlternateKeys(EntityReference er)
         {
             var resolvedId = GetRecordUniqueId(er);
-            
+
             return new EntityReference()
             {
                 LogicalName = er.LogicalName,
@@ -361,7 +361,7 @@ namespace FakeXrmEasy
                         Data["systemuser"].Add(CallerId.Id, new Entity("systemuser") { Id = CallerId.Id });
                     }
                 }
-                
+
             }
 
             var isManyToManyRelationshipEntity = e.LogicalName != null && this.Relationships.ContainsKey(e.LogicalName);

--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -26,9 +26,11 @@ namespace FakeXrmEasy
                 ProxyTypesAssemblies.Select(a => FindReflectedType(logicalName, a))
                                     .Where(t => t != null);
 
-            if(types.Count() > 1) {
+            if (types.Count() > 1)
+            {
                 var errorMsg = $"Type { logicalName } is defined in multiple assemblies: ";
-                foreach(var type in types) {
+                foreach (var type in types)
+                {
                     errorMsg += type.Assembly
                                     .GetName()
                                     .Name + "; ";
@@ -329,11 +331,11 @@ namespace FakeXrmEasy
             }
 
             IQueryable<Entity> inner = null;
-            if(le.JoinOperator == JoinOperator.LeftOuter)
+            if (le.JoinOperator == JoinOperator.LeftOuter)
             {
                 //inner = context.CreateQuery<Entity>(le.LinkToEntityName);
 
-                
+
                 //filters are applied in the inner query and then ignored during filter evaluation
                 var outerQueryExpression = new QueryExpression()
                 {
@@ -344,14 +346,14 @@ namespace FakeXrmEasy
 
                 var outerQuery = TranslateQueryExpressionToLinq(context, outerQueryExpression);
                 inner = outerQuery;
-                
+
             }
             else
             {
                 //Filters are applied after joins
                 inner = context.CreateQuery<Entity>(le.LinkToEntityName);
             }
-            
+
             //if (!le.Columns.AllColumns && le.Columns.Columns.Count == 0)
             //{
             //    le.Columns.AllColumns = true;   //Add all columns in the joined entity, otherwise we can't filter by related attributes, then the Select will actually choose which ones we need
@@ -373,7 +375,7 @@ namespace FakeXrmEasy
                     query = query.Join(inner,
                                     outerKey => outerKey.KeySelector(linkFromAlias, context),
                                     innerKey => innerKey.KeySelector(le.LinkToAttributeName, context),
-                                    (outerEl, innerEl) => outerEl.Clone(outerEl.GetType()).JoinAttributes(innerEl, new ColumnSet(true), leAlias, context));
+                                    (outerEl, innerEl) => outerEl.Clone(outerEl.GetType(), context).JoinAttributes(innerEl, new ColumnSet(true), leAlias, context));
 
                     break;
                 case JoinOperator.LeftOuter:
@@ -549,7 +551,7 @@ namespace FakeXrmEasy
             }
 
             //Project the attributes in the root column set  (must be applied after the where and order clauses, not before!!)
-            query = query.Select(x => x.Clone(x.GetType()).ProjectAttributes(qe, context));
+            query = query.Select(x => x.Clone(x.GetType(), context).ProjectAttributes(qe, context));
 
             return query;
         }
@@ -807,7 +809,7 @@ namespace FakeXrmEasy
                 OrganizationServiceFaultOperatorIsNotValidException.Throw();
             }
         }
-        
+
         protected static Expression GetAppropiateTypedValue(object value)
         {
             //Basic types conversions
@@ -1578,7 +1580,7 @@ namespace FakeXrmEasy
                 case ConditionOperator.ThisYear: // From first day of this year to last day of this year
                     fromDate = new DateTime(thisYear, 1, 1);
                     toDate = new DateTime(thisYear, 12, 31);
-                    break;                
+                    break;
                 case ConditionOperator.LastYear: // From first day of last year to last day of last year
                     fromDate = new DateTime(thisYear - 1, 1, 1);
                     toDate = new DateTime(thisYear - 1, 12, 31);
@@ -1995,7 +1997,7 @@ namespace FakeXrmEasy
             }
 
             c.Values[0] = (currentDateTime);
-            c.Values.Add(nextDateTime);            
+            c.Values.Add(nextDateTime);
             // c.Values.Add(numberOfWeeks);
 
             return TranslateConditionExpressionBetween(tc, getAttributeValueExpr, containsAttributeExpr);

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestRetrieve.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestRetrieve.cs
@@ -16,7 +16,7 @@ namespace FakeXrmEasy.Tests
         public void When_retrieve_is_invoked_with_an_empty_logical_name_an_exception_is_thrown()
         {
             var context = new XrmFakedContext();
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve(null, Guid.Empty, new ColumnSet()));
             Assert.Equal(ex.Message, "The entity logical name must not be null or empty.");
@@ -32,7 +32,7 @@ namespace FakeXrmEasy.Tests
         public void When_retrieve_is_invoked_with_an_empty_guid_an_exception_is_thrown()
         {
             var context = new XrmFakedContext();
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.Empty, new ColumnSet()));
             Assert.Equal(ex.Message, "The id must not be empty.");
@@ -42,7 +42,7 @@ namespace FakeXrmEasy.Tests
         public void When_retrieve_is_invoked_with_a_null_columnset_exception_is_thrown()
         {
             var context = new XrmFakedContext();
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.NewGuid(), null));
             Assert.Equal(ex.Message, "The columnset parameter must not be null.");
@@ -53,7 +53,7 @@ namespace FakeXrmEasy.Tests
         {
             var context = new XrmFakedContext();
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.NewGuid(), null));
             Assert.Equal(ex.Message, "The columnset parameter must not be null.");
@@ -72,7 +72,7 @@ namespace FakeXrmEasy.Tests
 
             context.Initialize(data);
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Retrieve("account", Guid.NewGuid(), new ColumnSet()));
         }
@@ -90,7 +90,7 @@ namespace FakeXrmEasy.Tests
 
             context.Initialize(data);
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var result = service.Retrieve("account", guid, new ColumnSet());
             Assert.Equal(result.Id, data.FirstOrDefault().Id);
@@ -109,7 +109,7 @@ namespace FakeXrmEasy.Tests
 
             context.Initialize(data);
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var result = service.Retrieve("account", guid, new ColumnSet(true));
             Assert.Equal(result.Id, data.FirstOrDefault().Id);
@@ -130,7 +130,7 @@ namespace FakeXrmEasy.Tests
             var data = new List<Entity>() { entity }.AsQueryable();
             context.Initialize(data);
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var result = service.Retrieve("account", guid, new ColumnSet(new string[] { "name" }));
             Assert.Equal(result.Id, data.FirstOrDefault().Id);
@@ -152,7 +152,7 @@ namespace FakeXrmEasy.Tests
             var data = new List<Entity>() { account }.AsQueryable();
             context.Initialize(data);
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
             var result = service.Retrieve("account", guid, new ColumnSet(new string[] { "name" }));
 
@@ -165,7 +165,7 @@ namespace FakeXrmEasy.Tests
             var context = new XrmFakedContext();
             context.ProxyTypesAssembly = Assembly.GetAssembly(typeof(Account));
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
             Assert.Throws<FaultException<OrganizationServiceFault>>(() => service.Retrieve("account", Guid.NewGuid(), new ColumnSet(true)));
         }
 
@@ -173,7 +173,7 @@ namespace FakeXrmEasy.Tests
         public void Should_Not_Fail_On_Retrieving_Entity_With_Entity_Collection_Attributes()
         {
             var ctx = new XrmFakedContext();
-            var service = ctx.GetFakedOrganizationService();
+            var service = ctx.GetOrganizationService();
 
             var party = new ActivityParty
             {


### PR DESCRIPTION
As discussed in #366 to have the `Name` property of `EntityReference` populated, we must use `PrimaryNameAttribute` from `EntityMetadata` when the data is available in the context.