### PR TITLE
Orders are copied in the translation from QueryByAttribute to QueryExpression

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveMultipleRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveMultipleRequestExecutor.cs
@@ -62,6 +62,11 @@ namespace FakeXrmEasy.FakeMessageExecutors
                     qe.Criteria.AddCondition(new ConditionExpression(query.Attributes[i], ConditionOperator.Equal, query.Values[i]));
                 }
 
+                foreach (var order in query.Orders)
+                {
+                    qe.AddOrder(order.AttributeName, order.OrderType);
+                }
+
                 qe.PageInfo = query.PageInfo;
 
                 // QueryExpression now done... execute it!

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/QueryByAttribute/QueryByAttributeTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/QueryByAttribute/QueryByAttributeTests.cs
@@ -5,12 +5,48 @@ using Microsoft.Xrm.Sdk.Query;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xunit;
 
 namespace FakeXrmEasy.Tests.FakeContextTests.QueryByAttributeTests
 {
     public class Tests
     {
+        [Fact]
+        public static void Order_is_respected_for_query_by_attribute()
+        {
+            var fakedContext = new XrmFakedContext();
+            var fakedService = fakedContext.GetOrganizationService();
+
+            var contact1 = new Contact
+            {
+                Id = Guid.NewGuid(),
+                LastName = "Old",
+                BirthDate = new DateTime(1980)
+            };
+
+            var contact2 = new Contact
+            {
+                Id = Guid.NewGuid(),
+                LastName = "Young",
+                BirthDate = new DateTime(1981)
+            };
+
+            fakedContext.Initialize(new List<Entity> { contact1, contact2 });
+
+            QueryByAttribute query = new QueryByAttribute("contact")
+            {
+                ColumnSet = new ColumnSet("lastname", "birthdate")
+            };
+            query.AddOrder("birthdate", OrderType.Descending);
+            var results = fakedService.RetrieveMultiple(query);
+
+            var ordered = results.Entities.Cast<Contact>().ToArray();
+
+            Assert.Equal("Young", ordered[0].LastName);
+            Assert.Equal("Old", ordered[1].LastName);
+        }
+
         [Fact]
         public static void When_a_query_by_attribute_is_executed_with_one_attribute_right_result_is_returned()
         {


### PR DESCRIPTION
Hello @jordimontana82 ,
There is a bug in the translation from QueryByAttribute to QueryExpression because QueryByAttribute.Orders is being ignored, as discussed in issue #375.

Unit test provided by @AngelRodriguez8008.

This PR fixes #375. 

