### PR TITLE
IOrganizationService.Retrieve uses RetrieveRequestExecutor.

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveRequestExecutor.cs
@@ -3,6 +3,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using System;
+using System.ServiceModel;
 
 namespace FakeXrmEasy.FakeMessageExecutors
 {
@@ -13,7 +14,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
             return request.GetType().Equals(GetResponsibleRequestType());
         }
 
-     
+
 
         public OrganizationResponse Execute(OrganizationRequest req, XrmFakedContext context)
         {
@@ -24,118 +25,140 @@ namespace FakeXrmEasy.FakeMessageExecutors
                 throw new ArgumentNullException("Target", "RetrieveRequest without Target is invalid.");
             }
 
-            var service = context.GetOrganizationService();
-            var targetId = context.GetRecordUniqueId(request.Target);
-            var resultEntity = service.Retrieve(request.Target.LogicalName, targetId, request.ColumnSet);
-            resultEntity.ApplyDateBehaviour(context);
-
-            if (request.RelatedEntitiesQuery != null && request.RelatedEntitiesQuery.Count > 0)
+            var entityName = request.Target.LogicalName;
+            var columnSet = request.ColumnSet;
+            if (columnSet == null)
             {
-                foreach (var relatedEntitiesQuery in request.RelatedEntitiesQuery)
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), "The columnset parameter must not be null.");
+            }
+
+            var id = context.GetRecordUniqueId(request.Target);
+
+            //Entity logical name exists, so , check if the requested entity exists
+            if (context.Data.ContainsKey(entityName) && context.Data[entityName] != null
+                && context.Data[entityName].ContainsKey(id))
+            {
+                //Return the subset of columns requested only
+                var reflectedType = context.FindReflectedType(entityName);
+
+                //Entity found => return only the subset of columns specified or all of them
+                var resultEntity = context.Data[entityName][id].Clone(reflectedType);
+                if (!columnSet.AllColumns)
                 {
-                    if (relatedEntitiesQuery.Value == null)
+                    resultEntity = resultEntity.ProjectAttributes(columnSet, context);
+                }
+                resultEntity.ApplyDateBehaviour(context);
+
+                if (request.RelatedEntitiesQuery != null && request.RelatedEntitiesQuery.Count > 0)
+                {
+                    foreach (var relatedEntitiesQuery in request.RelatedEntitiesQuery)
                     {
-                        throw new ArgumentNullException("relateEntitiesQuery.Value",
-                            string.Format("RelatedEntitiesQuery for \"{0}\" does not contain a Query Expression.",
-                                relatedEntitiesQuery.Key.SchemaName));
-                    }
-
-                    var fakeRelationship = context.GetRelationship(relatedEntitiesQuery.Key.SchemaName);
-                    if (fakeRelationship == null)
-                    {
-                        throw new Exception(string.Format("Relationship \"{0}\" does not exist in the metadata cache.",
-                            relatedEntitiesQuery.Key.SchemaName));
-                    }
-
-                    var relatedEntitiesQueryValue = (QueryExpression)relatedEntitiesQuery.Value;
-                    QueryExpression retrieveRelatedEntitiesQuery = relatedEntitiesQueryValue.Clone();
-
-                    if (fakeRelationship.RelationshipType == XrmFakedRelationship.enmFakeRelationshipType.OneToMany)
-                    {
-                        var isFrom1to2 = relatedEntitiesQueryValue.EntityName == fakeRelationship.Entity1LogicalName
-                            || request.Target.LogicalName != fakeRelationship.Entity1LogicalName
-                            || string.IsNullOrWhiteSpace(relatedEntitiesQueryValue.EntityName);
-
-                        if (isFrom1to2)
+                        if (relatedEntitiesQuery.Value == null)
                         {
-                            var fromAttribute = isFrom1to2 ? fakeRelationship.Entity1Attribute : fakeRelationship.Entity2Attribute;
-                            var toAttribute = isFrom1to2 ? fakeRelationship.Entity2Attribute : fakeRelationship.Entity1Attribute;
+                            throw new ArgumentNullException("relateEntitiesQuery.Value",
+                                string.Format("RelatedEntitiesQuery for \"{0}\" does not contain a Query Expression.",
+                                    relatedEntitiesQuery.Key.SchemaName));
+                        }
+
+                        var fakeRelationship = context.GetRelationship(relatedEntitiesQuery.Key.SchemaName);
+                        if (fakeRelationship == null)
+                        {
+                            throw new Exception(string.Format("Relationship \"{0}\" does not exist in the metadata cache.",
+                                relatedEntitiesQuery.Key.SchemaName));
+                        }
+
+                        var relatedEntitiesQueryValue = (QueryExpression)relatedEntitiesQuery.Value;
+                        QueryExpression retrieveRelatedEntitiesQuery = relatedEntitiesQueryValue.Clone();
+
+                        if (fakeRelationship.RelationshipType == XrmFakedRelationship.enmFakeRelationshipType.OneToMany)
+                        {
+                            var isFrom1to2 = relatedEntitiesQueryValue.EntityName == fakeRelationship.Entity1LogicalName
+                                || request.Target.LogicalName != fakeRelationship.Entity1LogicalName
+                                || string.IsNullOrWhiteSpace(relatedEntitiesQueryValue.EntityName);
+
+                            if (isFrom1to2)
+                            {
+                                var fromAttribute = isFrom1to2 ? fakeRelationship.Entity1Attribute : fakeRelationship.Entity2Attribute;
+                                var toAttribute = isFrom1to2 ? fakeRelationship.Entity2Attribute : fakeRelationship.Entity1Attribute;
+
+                                var linkEntity = new LinkEntity
+                                {
+                                    Columns = new ColumnSet(false),
+                                    LinkFromAttributeName = fromAttribute,
+                                    LinkFromEntityName = retrieveRelatedEntitiesQuery.EntityName,
+                                    LinkToAttributeName = toAttribute,
+                                    LinkToEntityName = resultEntity.LogicalName
+                                };
+
+                                if (retrieveRelatedEntitiesQuery.Criteria == null)
+                                {
+                                    retrieveRelatedEntitiesQuery.Criteria = new FilterExpression();
+                                }
+
+                                retrieveRelatedEntitiesQuery.Criteria
+                                    .AddFilter(LogicalOperator.And)
+                                    .AddCondition(linkEntity.LinkFromAttributeName, ConditionOperator.Equal, resultEntity.Id);
+                            }
+                            else
+                            {
+                                var link = retrieveRelatedEntitiesQuery.AddLink(fakeRelationship.Entity1LogicalName, fakeRelationship.Entity2Attribute, fakeRelationship.Entity1Attribute);
+                                link.LinkCriteria.AddCondition(resultEntity.LogicalName + "id", ConditionOperator.Equal, resultEntity.Id);
+                            }
+                        }
+                        else
+                        {
+                            var isFrom1 = fakeRelationship.Entity1LogicalName == retrieveRelatedEntitiesQuery.EntityName;
+                            var linkAttributeName = isFrom1 ? fakeRelationship.Entity1Attribute : fakeRelationship.Entity2Attribute;
+                            var conditionAttributeName = isFrom1 ? fakeRelationship.Entity2Attribute : fakeRelationship.Entity1Attribute;
 
                             var linkEntity = new LinkEntity
                             {
                                 Columns = new ColumnSet(false),
-                                LinkFromAttributeName = fromAttribute,
+                                LinkFromAttributeName = linkAttributeName,
                                 LinkFromEntityName = retrieveRelatedEntitiesQuery.EntityName,
-                                LinkToAttributeName = toAttribute,
-                                LinkToEntityName = resultEntity.LogicalName
-                            };
-
-                            if (retrieveRelatedEntitiesQuery.Criteria == null)
-                            {
-                                retrieveRelatedEntitiesQuery.Criteria = new FilterExpression();
-                            }
-
-                            retrieveRelatedEntitiesQuery.Criteria
-                                .AddFilter(LogicalOperator.And)
-                                .AddCondition(linkEntity.LinkFromAttributeName, ConditionOperator.Equal, resultEntity.Id);
-                        }
-                        else
-                        {
-                            var link = retrieveRelatedEntitiesQuery.AddLink(fakeRelationship.Entity1LogicalName, fakeRelationship.Entity2Attribute, fakeRelationship.Entity1Attribute);
-                            link.LinkCriteria.AddCondition(resultEntity.LogicalName + "id", ConditionOperator.Equal, resultEntity.Id);
-                        }
-                    }
-                    else
-                    {
-                        var isFrom1 = fakeRelationship.Entity1LogicalName == retrieveRelatedEntitiesQuery.EntityName;
-                        var linkAttributeName = isFrom1 ? fakeRelationship.Entity1Attribute : fakeRelationship.Entity2Attribute;
-                        var conditionAttributeName = isFrom1 ? fakeRelationship.Entity2Attribute : fakeRelationship.Entity1Attribute;
-
-                        var linkEntity = new LinkEntity
-                        {
-                            Columns = new ColumnSet(false),
-                            LinkFromAttributeName = linkAttributeName,
-                            LinkFromEntityName = retrieveRelatedEntitiesQuery.EntityName,
-                            LinkToAttributeName = linkAttributeName,
-                            LinkToEntityName = fakeRelationship.IntersectEntity,
-                            LinkCriteria = new FilterExpression
-                            {
-                                Conditions =
+                                LinkToAttributeName = linkAttributeName,
+                                LinkToEntityName = fakeRelationship.IntersectEntity,
+                                LinkCriteria = new FilterExpression
+                                {
+                                    Conditions =
                                 {
                                     new ConditionExpression(conditionAttributeName , ConditionOperator.Equal, resultEntity.Id)
                                 }
-                            }
+                                }
+                            };
+                            retrieveRelatedEntitiesQuery.LinkEntities.Add(linkEntity);
+                        }
+
+                        var retrieveRelatedEntitiesRequest = new RetrieveMultipleRequest
+                        {
+                            Query = retrieveRelatedEntitiesQuery
                         };
-                        retrieveRelatedEntitiesQuery.LinkEntities.Add(linkEntity);
+
+                        //use of an executor directly; if to use service.RetrieveMultiple then the result will be
+                        //limited to the number of records per page (somewhere in future release).
+                        //ALL RECORDS are needed here.
+                        var executor = new RetrieveMultipleRequestExecutor();
+                        var retrieveRelatedEntitiesResponse = executor
+                            .Execute(retrieveRelatedEntitiesRequest, context) as RetrieveMultipleResponse;
+
+                        if (retrieveRelatedEntitiesResponse.EntityCollection.Entities.Count == 0)
+                            continue;
+
+                        resultEntity.RelatedEntities
+                            .Add(relatedEntitiesQuery.Key, retrieveRelatedEntitiesResponse.EntityCollection);
                     }
-
-                    var retrieveRelatedEntitiesRequest = new RetrieveMultipleRequest
-                    {
-                        Query = retrieveRelatedEntitiesQuery
-                    };
-
-                    //use of an executor directly; if to use service.RetrieveMultiple then the result will be
-                    //limited to the number of records per page (somewhere in future release).
-                    //ALL RECORDS are needed here.
-                    var executor = new RetrieveMultipleRequestExecutor();
-                    var retrieveRelatedEntitiesResponse = executor
-                        .Execute(retrieveRelatedEntitiesRequest, context) as RetrieveMultipleResponse;
-
-                    if (retrieveRelatedEntitiesResponse.EntityCollection.Entities.Count == 0)
-                        continue;
-
-                    resultEntity.RelatedEntities
-                        .Add(relatedEntitiesQuery.Key, retrieveRelatedEntitiesResponse.EntityCollection);
                 }
-            }
 
-            return new RetrieveResponse
-            {
-                Results = new ParameterCollection
+                return new RetrieveResponse
                 {
-                    { "Entity", resultEntity }
-                }
-            };
+                    Results = new ParameterCollection { { "Entity", resultEntity } }
+                };
+            }
+            else
+            {
+                // Entity not found in the context => FaultException
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{entityName} With Id = {id:D} Does Not Exist");
+            }
         }
 
         public Type GetResponsibleRequestType()

--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -87,61 +87,17 @@ namespace FakeXrmEasy
             A.CallTo(() => fakedService.Retrieve(A<string>._, A<Guid>._, A<ColumnSet>._))
                 .ReturnsLazily((string entityName, Guid id, ColumnSet columnSet) =>
                 {
-                    if (string.IsNullOrWhiteSpace(entityName))
+                    if (columnSet == null) throw new FaultException("Something unexpected happened.");
+                    RetrieveRequest retrieveRequest = new RetrieveRequest()
                     {
-                        throw new InvalidOperationException("The entity logical name must not be null or empty.");
-                    }
+                        Target = new EntityReference() { LogicalName = entityName, Id = id },
+                        ColumnSet = columnSet
+                    };
+                    var executor = context.FakeMessageExecutors[typeof(RetrieveRequest)];
 
-                    if (id == Guid.Empty)
-                    {
-                        throw new InvalidOperationException("The id must not be empty.");
-                    }
+                    RetrieveResponse retrieveResponse = (RetrieveResponse)executor.Execute(retrieveRequest, context);
 
-                    if (columnSet == null)
-                    {
-                        throw new InvalidOperationException("The columnset parameter must not be null.");
-                    }
-
-                    // Don't fail with invalid operation exception, if no record of this entity exists, but entity is known
-                    if (!context.Data.ContainsKey(entityName))
-                    {
-                        if (context.ProxyTypesAssembly == null)
-                        {
-                            throw new InvalidOperationException($"The entity logical name {entityName} is not valid.");
-                        }
-
-                        if (!context.ProxyTypesAssembly.GetTypes().Any(type => context.FindReflectedType(entityName) != null))
-                        {
-                            throw new InvalidOperationException($"The entity logical name {entityName} is not valid.");
-                        }
-                    }
-
-                    //Return the subset of columns requested only
-                    var reflectedType = context.FindReflectedType(entityName);
-
-                    //Entity logical name exists, so , check if the requested entity exists
-                    if (context.Data.ContainsKey(entityName) && context.Data[entityName] != null
-                        && context.Data[entityName].ContainsKey(id))
-                    {
-                        //Entity found => return only the subset of columns specified or all of them
-                        var foundEntity = context.Data[entityName][id].Clone(reflectedType);
-                        if (columnSet.AllColumns)
-                        {
-                            foundEntity.ApplyDateBehaviour(context);
-                            return foundEntity;
-                        }
-                        else
-                        {
-                            var projected = foundEntity.ProjectAttributes(columnSet, context);
-                            projected.ApplyDateBehaviour(context);
-                            return projected;
-                        }
-                    }
-                    else
-                    {
-                        // Entity not found in the context => FaultException
-                        throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{entityName} With Id = {id:D} Does Not Exist");
-                    }
+                    return retrieveResponse.Entity;
                 });
         }
         /// <summary>

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestRetrieve.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestRetrieve.cs
@@ -32,7 +32,8 @@ namespace FakeXrmEasy.Tests
         public void When_retrieve_is_invoked_with_an_empty_guid_an_exception_is_thrown()
         {
             var context = new XrmFakedContext();
-            var service = context.GetFakedOrganizationService();
+            context.Initialize(new Entity() { LogicalName = "account", Id = Guid.NewGuid() });
+            var service = context.GetOrganizationService();
 
             var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.Empty, new ColumnSet()));
             Assert.Equal(ex.Message, "The id must not be empty.");
@@ -42,10 +43,12 @@ namespace FakeXrmEasy.Tests
         public void When_retrieve_is_invoked_with_a_null_columnset_exception_is_thrown()
         {
             var context = new XrmFakedContext();
-            var service = context.GetFakedOrganizationService();
+            var account = new Entity() { LogicalName = "account", Id = Guid.NewGuid() };
+            context.Initialize(account);
+            var service = context.GetOrganizationService();
 
-            var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.NewGuid(), null));
-            Assert.Equal(ex.Message, "The columnset parameter must not be null.");
+            var ex = Assert.Throws<FaultException>(() => service.Retrieve("account", account.Id, null));
+            Assert.Equal("Something unexpected happened.", ex.Message);
         }
 
         [Fact]
@@ -53,10 +56,10 @@ namespace FakeXrmEasy.Tests
         {
             var context = new XrmFakedContext();
 
-            var service = context.GetFakedOrganizationService();
+            var service = context.GetOrganizationService();
 
-            var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.NewGuid(), null));
-            Assert.Equal(ex.Message, "The columnset parameter must not be null.");
+            var ex = Assert.Throws<InvalidOperationException>(() => service.Retrieve("account", Guid.NewGuid(), new ColumnSet(true)));
+            Assert.Equal("The entity logical name account is not valid.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Hello Jordi,
I believe that Centralizing the retrieve logic to one function, can avoid future problems with maintainability.  I also changed some tests because they were not implemented as stated :) 

Best regards,
Betim.
