### PR TITLE
Remove attribute from context entity when updating with null values.

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -206,7 +206,7 @@ namespace FakeXrmEasy.Extensions
                     clone.KeyAttributes.AddRange(original.KeyAttributes.Select(kvp => new KeyValuePair<string, object>(CloneAttribute(kvp.Key) as string, kvp.Value)).ToArray());
                 }
 #endif
-                    return clone;
+                return clone;
             }
             else if (type == typeof(BooleanManagedProperty))
             {
@@ -332,10 +332,7 @@ namespace FakeXrmEasy.Extensions
 
             foreach (var attKey in e.Attributes.Keys)
             {
-                if (e[attKey] != null)
-                {
-                    cloned[attKey] = CloneAttribute(e[attKey]);
-                }
+                cloned[attKey] = e[attKey] != null ? CloneAttribute(e[attKey]) : null;
             }
 
 #if !FAKE_XRM_EASY && !FAKE_XRM_EASY_2013 && !FAKE_XRM_EASY_2015
@@ -529,6 +526,6 @@ namespace FakeXrmEasy.Extensions
             return result;
         }
 
-        
+
     }
 }

--- a/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Crud.cs
@@ -190,11 +190,14 @@ namespace FakeXrmEasy
                 foreach (var sAttributeName in e.Attributes.Keys.ToList())
                 {
                     var attribute = e[sAttributeName];
-                    if (attribute is DateTime)
+                    if (attribute == null)
+                    {
+                        cachedEntity.Attributes.Remove(sAttributeName);
+                    }
+                    else if (attribute is DateTime)
                     {
                         cachedEntity[sAttributeName] = ConvertToUtc((DateTime)e[sAttributeName]);
                     }
-
                     else
                     {
                         if (attribute is EntityReference && ValidateReferences)
@@ -244,7 +247,7 @@ namespace FakeXrmEasy
         protected EntityReference ResolveEntityReferenceByAlternateKeys(EntityReference er)
         {
             var resolvedId = GetRecordUniqueId(er);
-            
+
             return new EntityReference()
             {
                 LogicalName = er.LogicalName,
@@ -361,7 +364,7 @@ namespace FakeXrmEasy
                         Data["systemuser"].Add(CallerId.Id, new Entity("systemuser") { Id = CallerId.Id });
                     }
                 }
-                
+
             }
 
             var isManyToManyRelationshipEntity = e.LogicalName != null && this.Relationships.ContainsKey(e.LogicalName);

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestUpdate.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/FakeContextTestUpdate.cs
@@ -51,6 +51,25 @@ namespace FakeXrmEasy.Tests
         }
 
         [Fact]
+        public void When_an_entity_is_updated_with_a_null_attribute_the_attribute_is_removed()
+        {
+            var context = new XrmFakedContext();
+            var entity = new Entity("entity") { Id = Guid.NewGuid() };
+            entity["attribute"] = 1;
+            context.Initialize(entity);
+
+            var update = new Entity("entity") { Id = entity.Id };
+            update["attribute"] = null;
+
+            var service = context.GetOrganizationService();
+            service.Update(update);
+
+            update = service.Retrieve("entity", update.Id, new ColumnSet(true));
+
+            Assert.False( update.Attributes.ContainsKey("attribute"));
+        }
+
+        [Fact]
         public void When_updating_an_entity_the_context_should_reflect_changes()
         {
             var context = new XrmFakedContext();


### PR DESCRIPTION
Hello Jordi,
when attributes are set to null on update they should be removed from the context entity, as Roger mentioned in #388 .

Fixes #388.
Best regards,
Betim.