### PR TITLE
LinkEntities can be joined on all attribute types.

### DIFF
--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -461,7 +461,7 @@ namespace FakeXrmEasy.Extensions
         /// <param name="e"></param>
         /// <param name="sAttributeName"></param>
         /// <returns></returns>
-        public static Guid KeySelector(this Entity e, string sAttributeName, XrmFakedContext context)
+        public static object KeySelector(this Entity e, string sAttributeName, XrmFakedContext context)
         {
             if (sAttributeName.Contains("."))
             {
@@ -497,10 +497,12 @@ namespace FakeXrmEasy.Extensions
 
             if (keyValue is EntityReference)
                 return (keyValue as EntityReference).Id;
-            if (keyValue is Guid)
-                return ((Guid)keyValue);
+            if (keyValue is OptionSetValue)
+                return (keyValue as OptionSetValue).Value;
+            if (keyValue is Money)
+                return (keyValue as Money).Value;
 
-            return Guid.Empty;
+            return keyValue;
         }
 
         /// <summary>

--- a/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
+++ b/FakeXrmEasy.Shared/Extensions/EntityExtensions.cs
@@ -486,21 +486,25 @@ namespace FakeXrmEasy.Extensions
             }
 
             object keyValue = null;
-            if (e[sAttributeName] is AliasedValue)
+            AliasedValue aliasedValue;
+            if ((aliasedValue = e[sAttributeName] as AliasedValue) != null)
             {
-                keyValue = (e[sAttributeName] as AliasedValue).Value;
+                keyValue = aliasedValue.Value;
             }
             else
             {
                 keyValue = e[sAttributeName];
             }
 
-            if (keyValue is EntityReference)
-                return (keyValue as EntityReference).Id;
-            if (keyValue is OptionSetValue)
-                return (keyValue as OptionSetValue).Value;
-            if (keyValue is Money)
-                return (keyValue as Money).Value;
+            EntityReference entityReference;
+            if ((entityReference = keyValue as EntityReference) != null)
+                return entityReference.Id;
+            OptionSetValue optionSetValue;
+            if ((optionSetValue = keyValue as OptionSetValue) != null)
+                return optionSetValue.Value;
+            Money money;
+            if ((money = keyValue as Money) != null)
+                return money.Value;
 
             return keyValue;
         }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
@@ -440,13 +440,13 @@ namespace FakeXrmEasy.Tests.FakeContextTests
         public static void Should_Not_Fail_On_Conditions_In_Link_Entities()
         {
             var fakedContext = new XrmFakedContext();
-            var fakedService = fakedContext.GetFakedOrganizationService();
+            var fakedService = fakedContext.GetOrganizationService();
 
             var testEntity1 = new Entity("entity1")
             {
                 Attributes = new AttributeCollection
                 {
-                    {"entity1attr", "test1"}
+                    {"entity1attr", "test2"}
                 }
             };
             var testEntity2 = new Entity("entity2")
@@ -506,6 +506,22 @@ namespace FakeXrmEasy.Tests.FakeContextTests
             var result = fakedService.RetrieveMultiple(query);
             Assert.NotEmpty(result.Entities);
             Assert.Equal(1, result.Entities.Count);
+        }
+
+        [Fact]
+        public void Entities_Can_Be_Linked_On_String_Attribute()
+        {
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+            var entity = new Entity("entity") { Id = Guid.NewGuid(), ["name"] = "test" };
+            context.Initialize(entity);
+            var query = new QueryExpression("entity");
+            query.ColumnSet = new ColumnSet(true);
+            query.AddLink("entity", "name", "name");
+
+            var queryResult = service.RetrieveMultiple(query);
+
+            Assert.Equal(1, queryResult.Entities.Count);
         }
 
         [Fact]


### PR DESCRIPTION
Hello @jordimontana82,
as mentioned in issue #389 there was a problem that LinkEntity worked only on Guid or EntityReference. I changed KeySelector extension method to make the joins work on all entity types.

Fixes #389 
Best regards,
Betim.