### PR TITLE
Extended AddToQueueRequestExecutor

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/AddToQueueRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/AddToQueueRequestExecutor.cs
@@ -52,7 +52,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
             {
                 LogicalName = "queueitem",
                 // QueueItemProperties are used for initializing new queueitems
-                Attributes = queueItemProperties.Attributes
+                Attributes = queueItemProperties?.Attributes
             };
 
             createQueueItem["queueid"] = new EntityReference("queue", destinationQueueId);

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/AddToQueueRequestTests/AddToQueueRequestTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/AddToQueueRequestTests/AddToQueueRequestTests.cs
@@ -1,4 +1,5 @@
-﻿using FakeXrmEasy.FakeMessageExecutors;
+﻿using Crm;
+using FakeXrmEasy.FakeMessageExecutors;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
@@ -55,6 +56,105 @@ namespace FakeXrmEasy.Tests.FakeContextTests.AddToQueueRequestTests
 
             Assert.Equal(queue.ToEntityReference(), queueItem.GetAttributeValue<EntityReference>("queueid"));
             Assert.Equal(email.ToEntityReference(), queueItem.GetAttributeValue<EntityReference>("objectid"));
+        }
+
+        [Fact]
+        public void When_Queue_Item_Properties_Are_Passed_They_Are_Set_On_Create()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+            var workedBy = new EntityReference(SystemUser.EntityLogicalName, Guid.NewGuid());
+
+            var email = new Entity
+            {
+                LogicalName = Crm.Email.EntityLogicalName,
+                Id = Guid.NewGuid(),
+            };
+
+            var queue = new Entity
+            {
+                LogicalName = Crm.Queue.EntityLogicalName,
+                Id = Guid.NewGuid(),
+            };
+
+            context.Initialize(new[]
+            {
+                queue, email
+            });
+
+            var executor = new AddToQueueRequestExecutor();
+
+            var req = new AddToQueueRequest
+            {
+                DestinationQueueId = queue.Id,
+                Target = email.ToEntityReference(),
+                QueueItemProperties = new QueueItem
+                {
+                    WorkerId = workedBy
+                }
+            };
+
+            executor.Execute(req, context);
+
+            var queueItem = context.Data[Crm.QueueItem.EntityLogicalName].Values.Single();
+
+            Assert.Equal(queue.ToEntityReference(), queueItem.GetAttributeValue<EntityReference>("queueid"));
+            Assert.Equal(email.ToEntityReference(), queueItem.GetAttributeValue<EntityReference>("objectid"));
+            Assert.Equal(workedBy, queueItem.GetAttributeValue<EntityReference>("workerid"));
+        }
+
+        [Fact]
+        public void When_A_Queue_Item_Already_Exists_Use_Existing()
+        {
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+            var workedBy = new EntityReference(SystemUser.EntityLogicalName, Guid.NewGuid());
+
+            var email = new Entity
+            {
+                LogicalName = Crm.Email.EntityLogicalName,
+                Id = Guid.NewGuid(),
+            };
+
+            var queue = new Entity
+            {
+                LogicalName = Crm.Queue.EntityLogicalName,
+                Id = Guid.NewGuid(),
+            };
+
+            var queueItem = new QueueItem
+            {
+                LogicalName = Crm.Queue.EntityLogicalName,
+                Id = Guid.NewGuid(),
+                ObjectId = email.ToEntityReference()
+            };
+
+            context.Initialize(new[]
+            {
+                queue, email
+            });
+
+            var executor = new AddToQueueRequestExecutor();
+
+            var req = new AddToQueueRequest
+            {
+                DestinationQueueId = queue.Id,
+                Target = email.ToEntityReference(),
+                QueueItemProperties = new QueueItem
+                {
+                    WorkerId = workedBy
+                }
+            };
+
+            executor.Execute(req, context);
+
+            Assert.Equal(1, context.Data[Crm.QueueItem.EntityLogicalName].Values.Count);
+
+            queueItem = context.Data[Crm.QueueItem.EntityLogicalName].Values.Single().ToEntity<QueueItem>();
+
+            Assert.Equal(queue.ToEntityReference(), queueItem.GetAttributeValue<EntityReference>("queueid"));
+            Assert.Equal(email.ToEntityReference(), queueItem.GetAttributeValue<EntityReference>("objectid"));
+            Assert.Equal(workedBy, queueItem.GetAttributeValue<EntityReference>("workerid"));
         }
     }
 }


### PR DESCRIPTION
Hey @jordimontana82,

I extended the AddToQueueRequestExecutor to behave more like CRM actually does.
Is there a possibility to overwrite the default executor by my custom executor while this PR is pending?

Previously the ExecutionMocks and FakeMessageExecutors added to a XrmFakedContext were prioritized higher than the default implementations, but this does not seem to happen anymore.

Kind Regards,
Florian