### PR TITLE
EntityAlias is allowed to contain '.' character

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -315,7 +315,7 @@ namespace FakeXrmEasy
         {
             if (!string.IsNullOrEmpty(le.EntityAlias))
             {
-                if (!Regex.IsMatch(le.EntityAlias, "^[A-Za-z_]\\w*$", RegexOptions.ECMAScript))
+                if (!Regex.IsMatch(le.EntityAlias, "^[A-Za-z_](\\w|\\.)*$", RegexOptions.ECMAScript))
                 {
                     throw new FaultException(new FaultReason($"Invalid character specified for alias: {le.EntityAlias}. Only characters within the ranges [A-Z], [a-z] or [0-9] or _ are allowed.  The first character may only be in the ranges [A-Z], [a-z] or _."));
                 }

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/RetrieveMultipleTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/RetrieveMultipleTests.cs
@@ -389,5 +389,31 @@ namespace FakeXrmEasy.Tests.FakeContextTests.RetrieveMultiple
 
             Assert.Equal("Fake XrmEasy", accounts.Entities[0].GetAttributeValue<EntityReference>("ownerid").Name);
         }
+
+        [Fact]
+        public void Should_Allow_Using_Aliases_with_Dot()
+        {
+            var contact = new Entity("contact") { Id = Guid.NewGuid() };
+            contact["firstname"] = "Jordi";
+
+            var account = new Entity("account") { Id = Guid.NewGuid() };
+            account["primarycontactid"] = contact.ToEntityReference();
+            account["name"] = "Dynamics Value";
+
+            var context = new XrmFakedContext();
+            context.Initialize(new Entity[] { contact, account });
+            var service = context.GetOrganizationService();
+
+            QueryExpression query = new QueryExpression("account");
+            query.ColumnSet = new ColumnSet("name");
+            var link = query.AddLink("contact", "contactid", "primarycontactid");
+            link.EntityAlias = "primary.contact";
+            link.Columns = new ColumnSet("firstname");
+
+            var accounts = service.RetrieveMultiple(query);
+
+            Assert.True(accounts.Entities.First().Contains("primary.contact.firstname"));
+            Assert.Equal("Jordi", accounts.Entities.First().GetAttributeValue<AliasedValue>("primary.contact.firstname").Value);
+        }
     }
 }


### PR DESCRIPTION
Hello @jordimontana82 ,
as mentioned in issue #403 the latests CRM online allows '.' in the entity alias.

I fixed it with this PR even though the error message when there are disallowed characters does not specify '.' as an allowed character.

Best regards,
Betim.