### PR TITLE
 Performance improvement for getting entitymetadata by name

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Metadata.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Metadata.cs
@@ -80,9 +80,10 @@ namespace FakeXrmEasy
 
         public EntityMetadata GetEntityMetadataByName(string sLogicalName)
         {
-            return CreateMetadataQuery()
-                .Where(em => em.LogicalName.Equals(sLogicalName))
-                .FirstOrDefault();
+            if (EntityMetadata.ContainsKey(sLogicalName))
+                return EntityMetadata[sLogicalName].Copy();
+
+            return default;
         }
 
         public void SetEntityMetadata(EntityMetadata em)

--- a/FakeXrmEasy.Shared/XrmFakedContext.Metadata.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Metadata.cs
@@ -83,7 +83,7 @@ namespace FakeXrmEasy
             if (EntityMetadata.ContainsKey(sLogicalName))
                 return EntityMetadata[sLogicalName].Copy();
 
-            return default;
+            return null;
         }
 
         public void SetEntityMetadata(EntityMetadata em)


### PR DESCRIPTION
I had copied some entitymetadata (over 300 entities) from a development system and initialized it using the InitializeMetadata method, but calling GetEntityMetadataByName was taking several minutes to complete. This change means they are returned within ms