### PR TITLE
Update FakeXrmEasy.2016.nuspec

### DIFF
--- a/FakeXrmEasy.2016.nuspec
+++ b/FakeXrmEasy.2016.nuspec
@@ -15,10 +15,10 @@
     <tags>dynamics crm 2016 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
       <dependency id="FakeItEasy" version="[3.2.0]" />
-      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[8.0.0,8.2)" />
-      <dependency id="Microsoft.CrmSdk.Workflow" version="[8.0.0,8.2)" />
-      <dependency id="Microsoft.CrmSdk.Deployment" version="[8.0.0,8.2)" />
-      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="[8.0.0,8.2)" />
+      <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[8.0.0,8.2.0.2)" />
+      <dependency id="Microsoft.CrmSdk.Workflow" version="[8.0.0,8.2.0.2)" />
+      <dependency id="Microsoft.CrmSdk.Deployment" version="[8.0.0,8.2.0.2)" />
+      <dependency id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="[8.0.0,8.2.0.2)" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.Activities" targetFramework="net452" />


### PR DESCRIPTION
Accept the new versions of the Dynamics CRM 2016 libraries. This way we won't have to ignore the dependencies error when upgrading the libraries.