### PR TITLE
Upgraded FakeItEasy to 6.0.0

### DIFF
--- a/FakeXrmEasy.2011.nuspec
+++ b/FakeXrmEasy.2011.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2011 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[5.5.0]" />
+      <dependency id="FakeItEasy" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.Xrm.Sdk.2011" version="[5.0.18]" />
       <dependency id="Microsoft.Xrm.Sdk.Workflow.2011" version="[5.0.18]" />
       <dependency id="Microsoft.Crm.Sdk.Proxy.2011" version="[5.0.18]" />

--- a/FakeXrmEasy.2011.nuspec
+++ b/FakeXrmEasy.2011.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2011 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[3.2.0]" />
+      <dependency id="FakeItEasy" version="[5.5.0]" />
       <dependency id="Microsoft.Xrm.Sdk.2011" version="[5.0.18]" />
       <dependency id="Microsoft.Xrm.Sdk.Workflow.2011" version="[5.0.18]" />
       <dependency id="Microsoft.Crm.Sdk.Proxy.2011" version="[5.0.18]" />

--- a/FakeXrmEasy.2013.nuspec
+++ b/FakeXrmEasy.2013.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2013 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[5.5.0]" />
+      <dependency id="FakeItEasy" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[6.0.0,7.0)" />

--- a/FakeXrmEasy.2013.nuspec
+++ b/FakeXrmEasy.2013.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2013 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[3.2.0]" />
+      <dependency id="FakeItEasy" version="[5.5.0]" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[6.0.0,7.0)" />

--- a/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
+++ b/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
@@ -40,9 +40,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
+++ b/FakeXrmEasy.2013/FakeXrmEasy.2013.csproj
@@ -40,8 +40,11 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.6.0.4.1\lib\net40\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net40\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.2013/packages.config
+++ b/FakeXrmEasy.2013/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
   <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.Extensions" version="6.0.4.1" targetFramework="net40" />

--- a/FakeXrmEasy.2013/packages.config
+++ b/FakeXrmEasy.2013/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net40" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
   <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.Extensions" version="6.0.4.1" targetFramework="net40" />

--- a/FakeXrmEasy.2015.nuspec
+++ b/FakeXrmEasy.2015.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2015 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[3.2.0]" />
+      <dependency id="FakeItEasy" version="[5.5.0]" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[7.0.0.1,8.0)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[7.0.0.1,8.0)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[7.0.0.1,8.0)" />

--- a/FakeXrmEasy.2015.nuspec
+++ b/FakeXrmEasy.2015.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2015 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[5.5.0]" />
+      <dependency id="FakeItEasy" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[7.0.0.1,8.0)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[7.0.0.1,8.0)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[7.0.0.1,8.0)" />

--- a/FakeXrmEasy.2015/FakeXrmEasy.2015.csproj
+++ b/FakeXrmEasy.2015/FakeXrmEasy.2015.csproj
@@ -43,9 +43,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.7.1.1\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.2015/FakeXrmEasy.2015.csproj
+++ b/FakeXrmEasy.2015/FakeXrmEasy.2015.csproj
@@ -43,8 +43,11 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.7.1.1\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.2015/packages.config
+++ b/FakeXrmEasy.2015/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.2015/packages.config
+++ b/FakeXrmEasy.2015/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.2016.nuspec
+++ b/FakeXrmEasy.2016.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2016 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[3.2.0]" />
+      <dependency id="FakeItEasy" version="[5.5.0]" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[8.0.0,8.2)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[8.0.0,8.2)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[8.0.0,8.2)" />

--- a/FakeXrmEasy.2016.nuspec
+++ b/FakeXrmEasy.2016.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 2016 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[5.5.0]" />
+      <dependency id="FakeItEasy" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[8.0.0,8.2)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[8.0.0,8.2)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[8.0.0,8.2)" />

--- a/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
+++ b/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
@@ -40,8 +40,11 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
+++ b/FakeXrmEasy.2016/FakeXrmEasy.2016.csproj
@@ -40,9 +40,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.2016/packages.config
+++ b/FakeXrmEasy.2016/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.2016/packages.config
+++ b/FakeXrmEasy.2016/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.365.nuspec
+++ b/FakeXrmEasy.365.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 365 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[3.2.0]" />
+      <dependency id="FakeItEasy" version="[5.5.0]" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[8.2.0.1,9.0)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[8.2.0.1,9.0)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[8.2.0.1,9.0)" />

--- a/FakeXrmEasy.365.nuspec
+++ b/FakeXrmEasy.365.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 365 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[5.5.0]" />
+      <dependency id="FakeItEasy" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="[8.2.0.1,9.0)" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="[8.2.0.1,9.0)" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="[8.2.0.1,9.0)" />

--- a/FakeXrmEasy.365/FakeXrmEasy.365.csproj
+++ b/FakeXrmEasy.365/FakeXrmEasy.365.csproj
@@ -40,8 +40,11 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.0.999, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.1.0.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/FakeXrmEasy.365/FakeXrmEasy.365.csproj
+++ b/FakeXrmEasy.365/FakeXrmEasy.365.csproj
@@ -40,9 +40,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="ICSharpCode.SharpZipLib, Version=1.0.0.999, Culture=neutral, PublicKeyToken=1b03e6acf1164f73, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpZipLib.1.0.0\lib\net45\ICSharpCode.SharpZipLib.dll</HintPath>

--- a/FakeXrmEasy.365/packages.config
+++ b/FakeXrmEasy.365/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.365/packages.config
+++ b/FakeXrmEasy.365/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.9.nuspec
+++ b/FakeXrmEasy.9.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 365 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[5.5.0]" />
+      <dependency id="FakeItEasy" version="[6.0.0,7.0)" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="9.0.0.5"  />
       <dependency id="Microsoft.CrmSdk.Deployment" version="9.0.0.5"/>

--- a/FakeXrmEasy.9.nuspec
+++ b/FakeXrmEasy.9.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2014-2016</copyright>
     <tags>dynamics crm 365 unit testing xrm mock mocking fake fakes</tags>
     <dependencies>
-      <dependency id="FakeItEasy" version="[3.2.0]" />
+      <dependency id="FakeItEasy" version="[5.5.0]" />
       <dependency id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.5" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="9.0.0.5"  />
       <dependency id="Microsoft.CrmSdk.Deployment" version="9.0.0.5"/>

--- a/FakeXrmEasy.9/FakeXrmEasy.9.csproj
+++ b/FakeXrmEasy.9/FakeXrmEasy.9.csproj
@@ -37,9 +37,8 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.9/FakeXrmEasy.9.csproj
+++ b/FakeXrmEasy.9/FakeXrmEasy.9.csproj
@@ -37,8 +37,11 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.9/packages.config
+++ b/FakeXrmEasy.9/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.9/packages.config
+++ b/FakeXrmEasy.9/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
+++ b/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
@@ -38,8 +38,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net40\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -61,6 +64,7 @@
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
+++ b/FakeXrmEasy.Tests.2013/FakeXrmEasy.Tests.2013.csproj
@@ -38,9 +38,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.6.1.1\lib\net40\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests.2013/packages.config
+++ b/FakeXrmEasy.Tests.2013/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
   <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.Workflow" version="6.1.1" targetFramework="net4" />

--- a/FakeXrmEasy.Tests.2013/packages.config
+++ b/FakeXrmEasy.Tests.2013/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net40" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="6.1.1" targetFramework="net4" />
   <package id="Microsoft.CrmSdk.Deployment" version="6.1.1" targetFramework="net40" />
   <package id="Microsoft.CrmSdk.Workflow" version="6.1.1" targetFramework="net4" />

--- a/FakeXrmEasy.Tests.2015/FakeXrmEasy.Tests.2015.csproj
+++ b/FakeXrmEasy.Tests.2015/FakeXrmEasy.Tests.2015.csproj
@@ -44,9 +44,8 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.7.1.1\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests.2015/FakeXrmEasy.Tests.2015.csproj
+++ b/FakeXrmEasy.Tests.2015/FakeXrmEasy.Tests.2015.csproj
@@ -44,8 +44,11 @@
       <HintPath>..\packages\Microsoft.CrmSdk.Extensions.7.1.0.1\lib\net45\AntiXSSLibrary.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.7.1.1\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests.2015/packages.config
+++ b/FakeXrmEasy.Tests.2015/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.2015/packages.config
+++ b/FakeXrmEasy.Tests.2015/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
+++ b/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
@@ -39,8 +39,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -76,6 +79,7 @@
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.IdentityModel" />

--- a/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
+++ b/FakeXrmEasy.Tests.2016/FakeXrmEasy.Tests.2016.csproj
@@ -39,9 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.1.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests.2016/packages.config
+++ b/FakeXrmEasy.Tests.2016/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.1.0.2" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.2016/packages.config
+++ b/FakeXrmEasy.Tests.2016/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.1.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.1.0.2" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
+++ b/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
@@ -39,9 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
+++ b/FakeXrmEasy.Tests.365/FakeXrmEasy.Tests.365.csproj
@@ -39,8 +39,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.8.2.0.2\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -76,6 +79,7 @@
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.IdentityModel" />

--- a/FakeXrmEasy.Tests.365/packages.config
+++ b/FakeXrmEasy.Tests.365/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.365/packages.config
+++ b/FakeXrmEasy.Tests.365/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.2.0.2" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="8.2.0.2" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
+++ b/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
@@ -40,9 +40,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
+++ b/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
@@ -40,8 +40,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net45\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
@@ -75,6 +78,7 @@
     <Reference Include="System" />
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.IdentityModel" />

--- a/FakeXrmEasy.Tests.9/packages.config
+++ b/FakeXrmEasy.Tests.9/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net452" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.9/packages.config
+++ b/FakeXrmEasy.Tests.9/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net452" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
+++ b/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
@@ -39,8 +39,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net40\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.crm.sdk.proxy">
       <HintPath>..\packages\Microsoft.Crm.Sdk.Proxy.2011.5.0.18\lib\net40\microsoft.crm.sdk.proxy.dll</HintPath>
@@ -57,6 +60,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Activities" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>

--- a/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
+++ b/FakeXrmEasy.Tests/FakeXrmEasy.Tests.csproj
@@ -39,9 +39,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.crm.sdk.proxy">
       <HintPath>..\packages\Microsoft.Crm.Sdk.Proxy.2011.5.0.18\lib\net40\microsoft.crm.sdk.proxy.dll</HintPath>

--- a/FakeXrmEasy.Tests/packages.config
+++ b/FakeXrmEasy.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net40" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net40" />
   <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />

--- a/FakeXrmEasy.Tests/packages.config
+++ b/FakeXrmEasy.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
   <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />

--- a/FakeXrmEasy/FakeXrmEasy.csproj
+++ b/FakeXrmEasy/FakeXrmEasy.csproj
@@ -36,9 +36,8 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=3.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.3.2.0\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.crm.sdk.proxy">
       <HintPath>..\packages\Microsoft.Crm.Sdk.Proxy.2011.5.0.18\lib\net40\microsoft.crm.sdk.proxy.dll</HintPath>

--- a/FakeXrmEasy/FakeXrmEasy.csproj
+++ b/FakeXrmEasy/FakeXrmEasy.csproj
@@ -36,8 +36,11 @@
     <AssemblyOriginatorKeyFile>fakexrmeasy.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.5.5.0\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.3.1\lib\net40\Castle.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.6.0.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="microsoft.crm.sdk.proxy">
       <HintPath>..\packages\Microsoft.Crm.Sdk.Proxy.2011.5.0.18\lib\net40\microsoft.crm.sdk.proxy.dll</HintPath>

--- a/FakeXrmEasy/packages.config
+++ b/FakeXrmEasy/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
+  <package id="Castle.Core" version="4.3.1" targetFramework="net40" />
+  <package id="FakeItEasy" version="6.0.0" targetFramework="net40" />
   <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />

--- a/FakeXrmEasy/packages.config
+++ b/FakeXrmEasy/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="3.2.0" targetFramework="net40" />
+  <package id="FakeItEasy" version="5.5.0" targetFramework="net40" />
   <package id="Microsoft.Crm.Sdk.Proxy.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Client.2011" version="5.0.18" targetFramework="net40" />
   <package id="Microsoft.Xrm.Sdk.2011" version="5.0.18" targetFramework="net40" />


### PR DESCRIPTION
Rationale:
- FakeXrmEasy lib users might want to use more recent FakeItEasy version. 3.2.0 version is two and a half years old.
- Some projects want to migrate from spkl.fakes which references FakeItEasy >= 4.1.1. So it isn't possible to use both spkl.fakes and FakeXrmEasy in one test project.

Previous FakeItEasy versions changed how action exceptions are handled. They were wrapped in custom UserCallbackException. They actually reverted it back in version 5.3.0 (https://github.com/FakeItEasy/FakeItEasy/issues/1640).
So with zero code changed all tests are passed.