### PR TITLE
Return a clearer ErrorMessage for Invalid EntityFilter values

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveEntityRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveEntityRequestExecutor.cs
@@ -63,7 +63,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
                 return response;
             }
 
-            throw new Exception("Entity Filter not supported");
+            throw new Exception("At least EntityFilters.Entity or EntityFilters.Attributes must be present on EntityFilters of Request.");
         }
 
         public Type GetResponsibleRequestType()


### PR DESCRIPTION
I stumbled upon this Error today while using FakeXrmEasy to unit test a plugin. Took me some time to figure out where exactly the error came from and what it meant. 
This is just an idea for what to return, it'd just be good for the receiver of the error to need less time to figure out what went wrong.