### PR TITLE
Issue #324 fix for left outer join

### DIFF
--- a/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Queries.cs
@@ -383,8 +383,8 @@ namespace FakeXrmEasy
                                     innerKey => innerKey.KeySelector(le.LinkToAttributeName, context),
                                     (outerEl, innerElemsCol) => new { outerEl, innerElemsCol })
                                                 .SelectMany(x => x.innerElemsCol.DefaultIfEmpty()
-                                                            , (x, y) => x.outerEl
-                                                                            .JoinAttributes(y, new ColumnSet(true), leAlias, context));
+                                                            , (x, y) => x.outerEl.Clone(x.outerEl.GetType(), context)
+                                                                         .JoinAttributes(y, new ColumnSet(true), leAlias, context));
 
 
                     break;

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/RetrieveMultiple/QueryLinkEntityTests.cs
@@ -1076,7 +1076,7 @@ namespace FakeXrmEasy.Tests.FakeContextTests
         }
 
         [Fact]
-        public void TestRetriveMultipleWithLinkEntityWithAlternateNullField()
+        public void TestRetrieveMultipleWithLinkEntityWithAlternateNullField()
         {
             // ARRANGE
 
@@ -1113,6 +1113,75 @@ namespace FakeXrmEasy.Tests.FakeContextTests
             query.ColumnSet = new ColumnSet("parentname");
 
             LinkEntity link = new LinkEntity("parent", "child", "parentid", "parent", JoinOperator.Inner);
+            link.EntityAlias = "c";
+            link.Columns = new ColumnSet("name", "myvalue");
+
+            query.LinkEntities.Add(link);
+
+            // ACT
+
+            DataCollection<Entity> results = service.RetrieveMultiple(query).Entities;
+
+            // ASSERT
+
+            // fields for the first entity work as expected...
+            string entity1Name = results[0].GetAttributeValue<AliasedValue>("c.name").Value as string;
+            string entity1Value = results[0].GetAttributeValue<AliasedValue>("c.myvalue").Value as string;
+
+            Assert.Equal("entity1", entity1Name);
+            Assert.Equal("value", entity1Value);
+
+            // fields for the second entity do not.  
+            // The child "name" field is correct, but the "myvalue" field is returning the value of the previous
+            // entity when it should be returning null
+            string entity2Name = results[1].GetAttributeValue<AliasedValue>("c.name").Value as string;
+            string entity2Value = results[1].GetAttributeValue<AliasedValue>("c.myvalue")?.Value as string;
+
+            // this works fine:
+            Assert.Equal("entity2", entity2Name);
+
+            // this fails (entity2Value is "value")
+            Assert.Equal(null, entity2Value);
+        }
+        
+        [Fact]
+        public void TestRetrieveMultipleWithLinkEntityWithAlternateNullFieldOuterJoin()
+        {
+            // ARRANGE
+
+            List<Entity> initialEntities = new List<Entity>();
+
+            Entity parentEntity = new Entity("parent");
+            parentEntity["parentname"] = "parent name";
+            parentEntity.Id = Guid.NewGuid();
+            initialEntities.Add(parentEntity);
+
+            // create the first child which has the "myvalue" field set to "value"
+            Entity childEntity1 = new Entity("child");
+            childEntity1["parent"] = parentEntity.ToEntityReference();
+            childEntity1["name"] = "entity1";
+            childEntity1["myvalue"] = "value";
+            childEntity1.Id = Guid.NewGuid();
+            initialEntities.Add(childEntity1);
+
+            // create the second child which has the "myvalue" field set to null
+            Entity childEntity2 = new Entity("child");
+            childEntity2["parent"] = parentEntity.ToEntityReference();
+            childEntity2["name"] = "entity2";
+            childEntity2["myvalue"] = null;
+            childEntity2.Id = Guid.NewGuid();
+            initialEntities.Add(childEntity2);
+
+            XrmFakedContext context = new XrmFakedContext();
+            IOrganizationService service = context.GetOrganizationService();
+
+            context.Initialize(initialEntities);
+
+            // the query selects the "parent" entity, and joins to the "child" entities
+            QueryExpression query = new QueryExpression("parent");
+            query.ColumnSet = new ColumnSet("parentname");
+
+            LinkEntity link = new LinkEntity("parent", "child", "parentid", "parent", JoinOperator.LeftOuter);
             link.EntityAlias = "c";
             link.Columns = new ColumnSet("name", "myvalue");
 


### PR DESCRIPTION
In issue #324 (PR #353), the fix works with inner join, but fails with left outer join. This PR fixes outer join in a similar way.

Note: I duplicated the test, since I was not able to add [Theory] to reuse the same test due to .Net 4.0 project settings.