### PR TITLE
Add WinQuoteRequest message support and tests

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/WinQuoteRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/WinQuoteRequestExecutor.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using System;
+using System.ServiceModel;
+
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class WinQuoteRequestExecutor : IFakeMessageExecutor
+    {
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is WinQuoteRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var winQuoteRequest = request as WinQuoteRequest;
+
+            if (winQuoteRequest.Status == null)
+            {
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{nameof(WinQuoteRequest.Status)} must not be null");
+            }
+
+            if (winQuoteRequest.QuoteClose == null)
+            {
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{nameof(WinQuoteRequest.QuoteClose)} must not be null");
+            }
+
+            var quote = winQuoteRequest.QuoteClose.GetAttributeValue<EntityReference>("quoteid");
+
+            if (quote == null)
+            {
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{nameof(WinQuoteRequest.QuoteClose)} must have a 'quoteid' EntityReference detailing the Quote to update");
+            }
+
+            if (!quote.LogicalName.Equals("quote", StringComparison.InvariantCultureIgnoreCase))
+            {
+                throw new FaultException<OrganizationServiceFault>(new OrganizationServiceFault(), $"{nameof(WinQuoteRequest.QuoteClose)} must have a 'quoteid' EntityReference that refers to a 'quote'; got '{quote.LogicalName}'");
+            }
+
+            Entity update = new Entity
+            {
+                Id = quote.Id,
+                LogicalName = quote.LogicalName,
+                Attributes = new AttributeCollection
+                {
+                    { "statuscode", winQuoteRequest.Status }
+                }
+            };
+
+            var service = ctx.GetOrganizationService();
+
+            service.Update(update);
+
+            return new WinQuoteResponse();
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(WinQuoteRequest);
+        }
+    }
+}

--- a/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
+++ b/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\XmlExtensionsForFetchXml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\AddListMembersListRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\WinQuoteRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\FetchXmlToQueryExpressionRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveExchangeRateRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\BulkDeleteRequestExecutor.cs" />

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/WinQuoteRequestTests/WinQuoteRequestTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/WinQuoteRequestTests/WinQuoteRequestTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.ServiceModel;
+using FakeXrmEasy.FakeMessageExecutors;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.FakeContextTests.WinQuoteRequestTests
+{
+    public enum QuoteStatusCode
+    {
+        Draft = 1,
+        Active = 2,
+        Open = 3,
+        Won = 4,
+        Lost = 5,
+        Canceled = 6,
+        Revised = 7
+    }
+
+    public class WinQuoteRequestTests
+    {
+        [Fact]
+        public static void When_diffrent_request_supplied_then_returns_false()
+        {
+            var executor = new WinQuoteRequestExecutor();
+
+            Assert.False(executor.CanExecute(new RetrieveMultipleRequest()));
+        }
+
+        [Fact]
+        public static void When_null_quoteclose_supplied_then_throws()
+        {
+            var executor = new WinQuoteRequestExecutor();
+            var context = new XrmFakedContext();
+            var request = new WinQuoteRequest
+            {
+                QuoteClose = null,
+                Status = new OptionSetValue((int)QuoteStatusCode.Draft)
+            };
+
+            Assert.Throws<FaultException<OrganizationServiceFault>>(() => executor.Execute(request, context));
+        }
+
+        [Fact]
+        public static void When_null_quoteid_on_quoteclose_supplied_then_throws()
+        {
+            var executor = new WinQuoteRequestExecutor();
+            var context = new XrmFakedContext();
+            var request = new WinQuoteRequest
+            {
+                QuoteClose = new Entity
+                {
+                    LogicalName = "quoteclose",
+                    Attributes = new AttributeCollection
+                    {
+                        { "quoteid", null }
+                    }
+                },
+                Status = new OptionSetValue((int)QuoteStatusCode.Draft)
+            };
+
+            Assert.Throws<FaultException<OrganizationServiceFault>>(() => executor.Execute(request, context));
+        }
+
+        [Fact]
+        public static void When_nonquote_quoteid_on_quoteclose_supplied_then_throws()
+        {
+            var executor = new WinQuoteRequestExecutor();
+            var context = new XrmFakedContext();
+            var request = new WinQuoteRequest
+            {
+                QuoteClose = new Entity
+                {
+                    LogicalName = "quoteclose",
+                    Attributes = new AttributeCollection
+                    {
+                        { "quoteid", new EntityReference("apples", Guid.NewGuid()) }
+                    }
+                },
+                Status = new OptionSetValue((int)QuoteStatusCode.Draft)
+            };
+
+            Assert.Throws<FaultException<OrganizationServiceFault>>(() => executor.Execute(request, context));
+        }
+
+        [Fact]
+        public static void When_null_status_supplied_then_throws()
+        {
+            var executor = new WinQuoteRequestExecutor();
+            var context = new XrmFakedContext();
+
+            var quote = new Entity
+            {
+                LogicalName = "quote",
+                Id = Guid.NewGuid(),
+                Attributes = new AttributeCollection
+                {
+                    { "statuscode", new OptionSetValue((int)QuoteStatusCode.Draft) }
+                }
+            };
+
+            context.Initialize(new[]
+            {
+                quote
+            });
+
+            var request = new WinQuoteRequest
+            {
+                QuoteClose = new Entity
+                {
+                    LogicalName = "quoteclose",
+                    Attributes = new AttributeCollection
+                    {
+                        { "quoteid", new EntityReference(quote.LogicalName, quote.Id) }
+                    }
+                },
+                Status = null
+            };
+
+            Assert.Throws<FaultException<OrganizationServiceFault>>(() => executor.Execute(request, context));
+        }
+
+        [Fact]
+        public static void When_valid_request_supplied_then_updates_quote_statuscode()
+        {
+            var executor = new WinQuoteRequestExecutor();
+            var context = new XrmFakedContext();
+            var service = context.GetOrganizationService();
+
+            var quote = new Entity
+            {
+                LogicalName = "quote",
+                Id = Guid.NewGuid(),
+                Attributes = new AttributeCollection
+                {
+                    { "statuscode", new OptionSetValue((int)QuoteStatusCode.Draft) }
+                }
+            };
+
+            context.Initialize(new[]
+            {
+                quote
+            });
+
+            var newStatus = QuoteStatusCode.Won;
+
+            var request = new WinQuoteRequest
+            {
+                QuoteClose = new Entity
+                {
+                    LogicalName = "quoteclose",
+                    Attributes = new AttributeCollection
+                    {
+                        { "quoteid", new EntityReference(quote.LogicalName, quote.Id) }
+                    }
+                },
+                Status = new OptionSetValue((int)newStatus)
+            };
+
+            executor.Execute(request, context);
+
+            var updatedQuote = service.Retrieve(quote.LogicalName, quote.Id, new ColumnSet("statuscode"));
+
+            Assert.Equal((int)newStatus, updatedQuote.GetAttributeValue<OptionSetValue>("statuscode")?.Value);
+        }
+    }
+}

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -100,6 +100,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\ValidateReferencesTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\WhoAmIRequest\WhoAmITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\WinOpportunityRequestTests\WinOpportunityTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\WinQuoteRequestTests\WinQuoteRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\XrmFakedRelationshipTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\RetrieveMultipleDataProviderTesting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GeneratedCode.cs" />


### PR DESCRIPTION
Added support for the [`WinQuoteRequest`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.crm.sdk.messages.winquoterequest?view=dynamics-general-ce-9) SDK Message. Implemented to mirror the already implemented [`CloseQuestExecutor`](https://github.com/jordimontana82/fake-xrm-easy/blob/master/FakeXrmEasy.Shared/FakeMessageExecutors/CloseQuoteRequestExecutor.cs).

Questions:
- Should the update of the `statecode` to `Won` also be implemented in the executor? Currently similar executors do not, so I have omitted it.
- Should the creation of the `QuoteClose` record also be implemented in the executor? Similar ones do not currently.