### PR TITLE
Corrected GetResponsibleRequestType

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/CloseIncidentRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/CloseIncidentRequestExecutor.cs
@@ -70,7 +70,7 @@ namespace FakeXrmEasy.FakeMessageExecutors
 
         public Type GetResponsibleRequestType()
         {
-            return typeof(CloseIncidentResponse);
+            return typeof(CloseIncidentRequest);
         }
     }
 }


### PR DESCRIPTION
Fix for Issue #516.
Corrected GetResponsibleRequestType to CloseIncidentRequest, was referencing CloseIncidentResponse.