### PR TITLE
Add new Fake Message: RetrieveCurrentOrganizationRequest

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveCurrentOrganizationRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/RetrieveCurrentOrganizationRequestExecutor.cs
@@ -1,0 +1,43 @@
+﻿#if FAKE_XRM_EASY_2015 || FAKE_XRM_EASY_2016 || FAKE_XRM_EASY_365 || FAKE_XRM_EASY_9
+using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Organization;
+
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class RetrieveCurrentOrganizationRequestExecutor : IFakeMessageExecutor
+    {
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is RetrieveCurrentOrganizationRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var req = (RetrieveCurrentOrganizationRequest)request;
+
+            OrganizationDetail organizationDetail = new OrganizationDetail();
+            organizationDetail.UrlName = "https://fakexrmeasy.crm.dynamics.com";
+            organizationDetail.UniqueName = "FakeXrmEasy";
+            organizationDetail.OrganizationVersion = "9.0.0.0";
+
+            return new RetrieveCurrentOrganizationResponse
+            {
+                Results = new ParameterCollection
+                {
+                    { "Detail", organizationDetail }
+                }
+            };
+            //throw new NotImplementedException();
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(RetrieveCurrentOrganizationRequest);
+        }
+    }
+}
+#endif

--- a/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
+++ b/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\XmlExtensionsForFetchXml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\AddListMembersListRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\FetchXmlToQueryExpressionRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveCurrentOrganizationRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveExchangeRateRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\BulkDeleteRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RemoveMembersTeamRequestExecutor.cs" />


### PR DESCRIPTION
Hi Jordi, I create new Fake Message **RetrieveCurrentOrganizationRequest**, which uses fake OrganizationUrl, Company and Organization.
I just need your help to fix preprocessor directives, because **RetrieveCurrentOrganizationRequest** is supported by FAKE_XRM_EASY.2015 and higher.
When I delete FAKE_XRM_EASY.2013 from preprocessor directives(1st line in commited file), whole code grayout so it will not be executed.
(Image 1 - code greyouts without FAKE_XRM_EASY.2013)
![image](https://user-images.githubusercontent.com/75648228/101462971-1f8c2a80-393d-11eb-8713-93a690a8d56e.png)

(Image 2 - code should be executed but it's not supported for FAKE_XRM_EASY.2013)
![image](https://user-images.githubusercontent.com/75648228/101463238-7691ff80-393d-11eb-98be-6277912aa25a.png)
