### PR TITLE
Added DeleteRecordChangeHistoryRequest Fake executor for Shared project.

### DIFF
--- a/FakeXrmEasy.Shared/FakeMessageExecutors/DeleteRecordChangeHistoryRequestExecutor.cs
+++ b/FakeXrmEasy.Shared/FakeMessageExecutors/DeleteRecordChangeHistoryRequestExecutor.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Crm.Sdk.Messages;
+using System;
+using System.ServiceModel;
+namespace FakeXrmEasy.FakeMessageExecutors
+{
+    public class DeleteRecordChangeHistoryRequestExecutor : IFakeMessageExecutor
+    {
+
+        public bool CanExecute(OrganizationRequest request)
+        {
+            return request is DeleteRecordChangeHistoryRequest;
+        }
+
+        public OrganizationResponse Execute(OrganizationRequest request, XrmFakedContext ctx)
+        {
+            var req = request as DeleteRecordChangeHistoryRequest;
+
+            var res = new DeleteRecordChangeHistoryResponse();
+
+            return res;
+        }
+
+        public Type GetResponsibleRequestType()
+        {
+            return typeof(DeleteRecordChangeHistoryRequest);
+        }
+    }
+
+}

--- a/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
+++ b/FakeXrmEasy.Shared/FakeXrmEasy.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TypeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\XmlExtensionsForFetchXml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\AddListMembersListRequestExecutor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\DeleteRecordChangeHistoryRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\FetchXmlToQueryExpressionRequestExecutor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\RetrieveExchangeRateRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeMessageExecutors\BulkDeleteRequestExecutor.cs" />

--- a/FakeXrmEasy.Tests.Shared/FakeContextTests/DeleteRecordChangeHistoryRequestTests/DeleteRecordChangeHistoryRequestTests.cs
+++ b/FakeXrmEasy.Tests.Shared/FakeContextTests/DeleteRecordChangeHistoryRequestTests/DeleteRecordChangeHistoryRequestTests.cs
@@ -1,0 +1,29 @@
+﻿using FakeXrmEasy.FakeMessageExecutors;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.FakeContextTests.DeleteRecordChangeHistoryRequestTests
+{
+    public class DeleteRecordChangeHistoryRequestTests
+    {
+        [Fact]
+        public void When_can_execute_is_called_with_an_invalid_request_result_is_false()
+        {
+            var executor = new DeleteRecordChangeHistoryRequestExecutor();
+            var anotherRequest = new RetrieveMultipleRequest();
+            Assert.False(executor.CanExecute(anotherRequest));
+        }
+
+        [Fact]
+        public void When_execute_is_called_with_a_null_target_exception_is_thrown()
+        {
+            var ctx = new XrmFakedContext();
+            var service = ctx.GetOrganizationService();
+            var orgReq = new OrganizationRequest();
+            var res = new DeleteRecordChangeHistoryRequestExecutor().Execute(orgReq, ctx);
+            Assert.IsType(typeof(DeleteRecordChangeHistoryResponse), res);
+        }
+    }
+}

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\AddListMembersListRequestTests\Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\AddMemberListRequestTests\Tests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\BulkDeleteRequestTests\BulkDeleteRequestTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\DeleteRecordChangeHistoryRequestTests\DeleteRecordChangeHistoryRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\FetchXmlToQueryExpressionRequestTests\FetchXmlToQueryExpressionRequestTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\QueryTranslationTests\ProjectionTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\RemoveUserFromRecordTeamRequestTests\RemoveUserFromRecordTeamRequestTests.cs" />


### PR DESCRIPTION
## Title 
Added DeleteRecordChangeHistoryRequestTest Fake executor for Test Shared project.

## Description

It has been included a quick fake DeleteRecordChangeHistory to fake the message in the Shared Projects. 
It has been created a DeleteRecordChangeHistory_Tests as well in the SharedTest project.