### PR TITLE
Support ILogger fake

### DIFF
--- a/FakeXrmEasy.9/FakeXrmEasy.9.csproj
+++ b/FakeXrmEasy.9/FakeXrmEasy.9.csproj
@@ -44,7 +44,7 @@
       <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -56,7 +56,7 @@
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.4\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/FakeXrmEasy.9/FakeXrmEasy.9.csproj
+++ b/FakeXrmEasy.9/FakeXrmEasy.9.csproj
@@ -43,8 +43,8 @@
     <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.28\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -55,8 +55,8 @@
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.4\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.28\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/FakeXrmEasy.9/FakeXrmEasy.9.csproj
+++ b/FakeXrmEasy.9/FakeXrmEasy.9.csproj
@@ -44,7 +44,7 @@
       <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -56,7 +56,7 @@
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.4\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/FakeXrmEasy.9/packages.config
+++ b/FakeXrmEasy.9/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.9" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.28" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.9/packages.config
+++ b/FakeXrmEasy.9/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.4" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.34" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.9/packages.config
+++ b/FakeXrmEasy.9/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.34" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.9" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -2,6 +2,9 @@
 using Microsoft.Xrm.Sdk;
 using System;
 using System.Linq;
+#if FAKE_XRM_EASY_9
+using Microsoft.Xrm.Sdk.PluginTelemetry;
+#endif
 
 namespace FakeXrmEasy
 {
@@ -379,9 +382,9 @@ namespace FakeXrmEasy
                        return GetFakedEntityDataSourceRetrieverService();
                    }
 
-                   if (t == typeof(Microsoft.Xrm.Sdk.PluginTelemetry.ILogger))
+                   if (t == typeof(ILogger))
                    {
-                       return A.Fake<Microsoft.Xrm.Sdk.PluginTelemetry.ILogger>();
+                       return _FakeLogger.Value;
                    }
 #endif
                    throw new PullRequestException("The specified service type is not supported");
@@ -392,6 +395,11 @@ namespace FakeXrmEasy
 
 #if FAKE_XRM_EASY_9
         public Entity EntityDataSourceRetriever { get; set; }
+
+        public ILogger GetLogger()
+        {
+            return _FakeLogger.Value;
+        }
 #endif
 
         public XrmFakedTracingService GetFakeTracingService()

--- a/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.Plugins.cs
@@ -378,6 +378,11 @@ namespace FakeXrmEasy
                    {
                        return GetFakedEntityDataSourceRetrieverService();
                    }
+
+                   if (t == typeof(Microsoft.Xrm.Sdk.PluginTelemetry.ILogger))
+                   {
+                       return A.Fake<Microsoft.Xrm.Sdk.PluginTelemetry.ILogger>();
+                   }
 #endif
                    throw new PullRequestException("The specified service type is not supported");
                });

--- a/FakeXrmEasy.Shared/XrmFakedContext.cs
+++ b/FakeXrmEasy.Shared/XrmFakedContext.cs
@@ -10,6 +10,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+#if FAKE_XRM_EASY_9
+using Microsoft.Xrm.Sdk.PluginTelemetry;
+#endif
 
 namespace FakeXrmEasy
 {
@@ -25,6 +28,10 @@ namespace FakeXrmEasy
         private IServiceEndpointNotificationService _serviceEndpointNotificationService;
 
         private readonly Lazy<XrmFakedTracingService> _tracingService = new Lazy<XrmFakedTracingService>(() => new XrmFakedTracingService());
+
+#if FAKE_XRM_EASY_9
+        private readonly Lazy<ILogger> _FakeLogger = new Lazy<ILogger>(() => A.Fake<ILogger>());
+#endif
 
         /// <summary>
         /// All proxy type assemblies available on mocked database.

--- a/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
+++ b/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
@@ -46,8 +46,9 @@
     <Reference Include="FakeItEasy, Version=6.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+    <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.28\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -58,8 +59,9 @@
     <Reference Include="Microsoft.Rest.ClientRuntime, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.4\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.28\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
+++ b/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
@@ -47,7 +47,7 @@
       <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -59,7 +59,7 @@
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.4\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.9\lib\net45\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>

--- a/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
+++ b/FakeXrmEasy.Tests.9/FakeXrmEasy.Tests.9.csproj
@@ -47,7 +47,7 @@
       <HintPath>..\packages\FakeItEasy.6.0.0\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=3.19.8.16603, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.3.19.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
@@ -59,7 +59,7 @@
       <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.2.4\lib\net452\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.34\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.4\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
@@ -79,6 +79,7 @@
     <Reference Include="System.Activities" />
     <Reference Include="System.Activities.Presentation" />
     <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.IdentityModel" />

--- a/FakeXrmEasy.Tests.9/packages.config
+++ b/FakeXrmEasy.Tests.9/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.9" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.28" targetFramework="net462" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.9/packages.config
+++ b/FakeXrmEasy.Tests.9/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.4" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.34" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.9/packages.config
+++ b/FakeXrmEasy.Tests.9/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.3.1" targetFramework="net452" />
   <package id="FakeItEasy" version="6.0.0" targetFramework="net452" />
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.34" targetFramework="net452" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.9" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.2.4" targetFramework="net452" />

--- a/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
+++ b/FakeXrmEasy.Tests.Shared/FakeXrmEasy.Tests.Shared.projitems
@@ -102,6 +102,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\WinOpportunityRequestTests\WinOpportunityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeContextTests\XrmFakedRelationshipTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FakeXrmEasyTestsBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Features\LoggerPluginTesting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Features\RetrieveMultipleDataProviderTesting.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GeneratedCode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue116.cs" />
@@ -125,6 +126,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Pipeline\PipelineTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\AccountSetTerritories.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\EntityImagesPlugin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\LoggerPlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\PostOperationUpdatePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\RetrieveMultipleDataProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginsForTesting\ServiceEndpointNotificationPlugin.cs" />

--- a/FakeXrmEasy.Tests.Shared/Features/LoggerPluginTesting.cs
+++ b/FakeXrmEasy.Tests.Shared/Features/LoggerPluginTesting.cs
@@ -1,0 +1,18 @@
+﻿#if FAKE_XRM_EASY_9
+using FakeXrmEasy.Tests.PluginsForTesting;
+using Xunit;
+
+namespace FakeXrmEasy.Tests.Features
+{
+    public class LoggerPluginTesting
+    {
+        [Fact]
+        public void IServiceProvider_should_has_ILogger_in_v9()
+        {
+            var context = new XrmFakedContext();
+
+            context.ExecutePluginWith<LoggerPlugin>();
+        }
+    }
+}
+#endif

--- a/FakeXrmEasy.Tests.Shared/Features/LoggerPluginTesting.cs
+++ b/FakeXrmEasy.Tests.Shared/Features/LoggerPluginTesting.cs
@@ -1,4 +1,5 @@
 ﻿#if FAKE_XRM_EASY_9
+using FakeItEasy;
 using FakeXrmEasy.Tests.PluginsForTesting;
 using Xunit;
 
@@ -12,6 +13,10 @@ namespace FakeXrmEasy.Tests.Features
             var context = new XrmFakedContext();
 
             context.ExecutePluginWith<LoggerPlugin>();
+
+            var logger = context.GetLogger();
+
+            A.CallTo(() => logger.LogInformation("Test")).MustHaveHappened(1, Times.Exactly);
         }
     }
 }

--- a/FakeXrmEasy.Tests.Shared/PluginsForTesting/LoggerPlugin.cs
+++ b/FakeXrmEasy.Tests.Shared/PluginsForTesting/LoggerPlugin.cs
@@ -1,0 +1,18 @@
+﻿#if FAKE_XRM_EASY_9
+using System;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Extensions;
+using Microsoft.Xrm.Sdk.PluginTelemetry;
+
+namespace FakeXrmEasy.Tests.PluginsForTesting
+{
+    public class LoggerPlugin : IPlugin
+    {
+        public void Execute(IServiceProvider serviceProvider)
+        {
+            var logger = serviceProvider.Get<ILogger>();
+            logger.LogInformation("Test");
+        }
+    }
+}
+#endif


### PR DESCRIPTION
When using `ILogger` in plugins, the context would throw `PullRequestException: The specified service type is not supported`.

This PR adds support for fake loggers.

Had to upgrade the core deps, since `ILogger` wasn't available. 

Let me know if you want any changes.